### PR TITLE
Message processor provider without IoC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+build_script:
+- cmd: dotnet build --configuration Release
+test_script:
+- cmd: >-
+    dotnet test tests/KnightBus.Core.Tests.Unit/KnightBus.Core.Tests.Unit.csproj --logger:Appveyor
+
+    dotnet test tests/KnightBus.Host.Tests.Unit/KnightBus.Host.Tests.Unit.csproj --logger:Appveyor
+artifacts:
+- path: '**\bin\Release\*.nupkg'
+deploy:
+- provider: NuGet
+  api_key:
+    secure: Y4Xs2fUHf8VLuWaLjv994vLx3qQZ1qAiFW7NKfg7wuq7OtmOWCpVgzYACiXN1x/s
+  on:
+    branch: master

--- a/src/KnightBus.Host/KnightBus.Host.csproj
+++ b/src/KnightBus.Host/KnightBus.Host.csproj
@@ -10,7 +10,7 @@
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus-documentation/master/media/images/knighbus-64.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/KnightBus.Host/MessageProcessor.cs
+++ b/src/KnightBus.Host/MessageProcessor.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/KnightBus.Host/MessageProcessor.cs
+++ b/src/KnightBus.Host/MessageProcessor.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/KnightBus.Host/StandardMessageProcessorProvider.cs
+++ b/src/KnightBus.Host/StandardMessageProcessorProvider.cs
@@ -10,15 +10,25 @@ namespace KnightBus.Host
     {
         private readonly ConcurrentDictionary<Type, object> _processors = new ConcurrentDictionary<Type, object>();
 
-        public StandardMessageProcessorProvider RegisterProcessor<T>(IProcessMessage<T> processor) where T : IMessage
+        public StandardMessageProcessorProvider RegisterProcessor(object processor)
         {
-            _processors[typeof(T)] = processor;
+            Register(processor, typeof(IProcessCommand<,>));
+            Register(processor, typeof(IProcessEvent<,,>));
             return this;
+        }
+
+        private void Register(object processor, Type type)
+        {
+            var processorInterfaces = ReflectionHelper.GetAllInterfacesImplementingOpenGenericInterface(processor.GetType(), type);
+            foreach (var processorInterface in processorInterfaces)
+            {
+                _processors[processorInterface] = processor;
+            }
         }
 
         public IProcessMessage<T> GetProcessor<T>(Type type) where T : IMessage
         {
-            return (IProcessMessage<T>) _processors[typeof(T)];
+            return (IProcessMessage<T>) _processors[type];
         }
 
         public IEnumerable<Type> ListAllProcessors()

--- a/src/KnightBus.Host/StandardMessageProcessorProvider.cs
+++ b/src/KnightBus.Host/StandardMessageProcessorProvider.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using KnightBus.Core;
+using KnightBus.Messages;
+
+namespace KnightBus.Host
+{
+    public class StandardMessageProcessorProvider : IMessageProcessorProvider
+    {
+        private readonly ConcurrentDictionary<Type, object> _processors = new ConcurrentDictionary<Type, object>();
+
+        public void RegisterProcessor<T>(IProcessMessage<T> processor) where T : IMessage
+        {
+            _processors[typeof(T)] = processor;
+        }
+
+
+        public IProcessMessage<T> GetProcessor<T>(Type type) where T : IMessage
+        {
+            return (IProcessMessage<T>) _processors[typeof(T)];
+        }
+
+        public IEnumerable<Type> ListAllProcessors()
+        {
+            return _processors.Keys;
+        }
+    }
+}

--- a/src/KnightBus.Host/StandardMessageProcessorProvider.cs
+++ b/src/KnightBus.Host/StandardMessageProcessorProvider.cs
@@ -10,11 +10,11 @@ namespace KnightBus.Host
     {
         private readonly ConcurrentDictionary<Type, object> _processors = new ConcurrentDictionary<Type, object>();
 
-        public void RegisterProcessor<T>(IProcessMessage<T> processor) where T : IMessage
+        public StandardMessageProcessorProvider RegisterProcessor<T>(IProcessMessage<T> processor) where T : IMessage
         {
             _processors[typeof(T)] = processor;
+            return this;
         }
-
 
         public IProcessMessage<T> GetProcessor<T>(Type type) where T : IMessage
         {

--- a/src/KnightBus.Host/StandardMessageProcessorProvider.cs
+++ b/src/KnightBus.Host/StandardMessageProcessorProvider.cs
@@ -6,10 +6,17 @@ using KnightBus.Messages;
 
 namespace KnightBus.Host
 {
+    /// <summary>
+    /// <see cref="IMessageProcessorProvider"/> when you don't need IoC. Will treat all <see cref="IProcessMessage{T}"/> as singletons.
+    /// </summary>
     public class StandardMessageProcessorProvider : IMessageProcessorProvider
     {
         private readonly ConcurrentDictionary<Type, object> _processors = new ConcurrentDictionary<Type, object>();
 
+        /// <summary>
+        /// Adds a <see cref="IProcessCommand{T,TSettings}"/> or <see cref="IProcessEvent{TTopic,TTopicSubscription,TSettings}"/> to the provider
+        /// </summary>
+        /// <param name="processor"><see cref="IProcessCommand{T,TSettings}"/> or <see cref="IProcessEvent{TTopic,TTopicSubscription,TSettings}"/></param>
         public StandardMessageProcessorProvider RegisterProcessor(object processor)
         {
             Register(processor, typeof(IProcessCommand<,>));

--- a/tests/KnightBus.Host.Tests.Unit/StandardMessageProcessorProviderTests.cs
+++ b/tests/KnightBus.Host.Tests.Unit/StandardMessageProcessorProviderTests.cs
@@ -1,0 +1,74 @@
+using System.Linq;
+using FluentAssertions;
+using KnightBus.Core;
+using KnightBus.Host.Tests.Unit.Processors;
+using Moq;
+using NUnit.Framework;
+
+namespace KnightBus.Host.Tests.Unit
+{
+    [TestFixture]
+    public class StandardMessageProcessorProviderTests
+    {
+        [Test]
+        public void Should_register_processor()
+        {
+            //arrange
+            var provider = new StandardMessageProcessorProvider();
+            //act
+            provider.RegisterProcessor(new SingleCommandProcessor(Mock.Of<ICountable>()));
+            //assert
+            provider.ListAllProcessors().Count().Should().Be(1);
+            provider.ListAllProcessors().FirstOrDefault().Should().Be(typeof(IProcessCommand<TestCommand, TestTopicSettings>));
+        }
+
+        [Test]
+        public void Should_get_registered_processor()
+        {
+            //arrange
+            var provider = new StandardMessageProcessorProvider();
+            var processor = new SingleCommandProcessor(Mock.Of<ICountable>());
+            provider.RegisterProcessor(processor);
+            //act
+            var processorFound = provider.GetProcessor<TestCommand>(typeof(IProcessCommand<TestCommand, TestTopicSettings>));
+            //assert
+            processorFound.Should().Be(processor);
+        }
+
+        [Test]
+        public void Should_register_multi_processor()
+        {
+            //arrange
+            var provider = new StandardMessageProcessorProvider();
+            //act
+            provider.RegisterProcessor(new MultipleCommandProcessor(Mock.Of<ICountable>()));
+            //assert
+            provider.ListAllProcessors().Count().Should().Be(2);
+            provider.ListAllProcessors().Should().Contain(x => x == typeof(IProcessCommand<TestCommandOne, TestTopicSettings>));
+            provider.ListAllProcessors().Should().Contain(x => x == typeof(IProcessCommand<TestCommandTwo, TestTopicSettings>));
+        }
+        [Test]
+        public void Should_register_event_processor()
+        {
+            //arrange
+            var provider = new StandardMessageProcessorProvider();
+            //act
+            provider.RegisterProcessor(new EventProcessor(Mock.Of<ICountable>()));
+            //assert
+            provider.ListAllProcessors().Count().Should().Be(1);
+            provider.ListAllProcessors().Should().Contain(x => x == typeof(IProcessEvent<TestEvent, TestSubscription, TestTopicSettings>));
+        }
+        [Test]
+        public void Should_get_registered_event_processor()
+        {
+            //arrange
+            var provider = new StandardMessageProcessorProvider();
+            var processor = new EventProcessor(Mock.Of<ICountable>());
+            provider.RegisterProcessor(processor);
+            //act
+            var processorFound = provider.GetProcessor<TestEvent>(typeof(IProcessEvent<TestEvent, TestSubscription, TestTopicSettings>));
+            //assert
+            processorFound.Should().Be(processor);
+        }
+    }
+}

--- a/tests/KnightBus.Host.Tests.Unit/StandardMessageProcessorProviderTests.cs
+++ b/tests/KnightBus.Host.Tests.Unit/StandardMessageProcessorProviderTests.cs
@@ -48,6 +48,20 @@ namespace KnightBus.Host.Tests.Unit
             provider.ListAllProcessors().Should().Contain(x => x == typeof(IProcessCommand<TestCommandTwo, TestTopicSettings>));
         }
         [Test]
+        public void Should_get_registered_multi_processor()
+        {
+            //arrange
+            var provider = new StandardMessageProcessorProvider();
+            var processor = new MultipleCommandProcessor(Mock.Of<ICountable>());
+            provider.RegisterProcessor(processor);
+            //act
+            var processorFound = provider.GetProcessor<TestCommandOne>(typeof(IProcessCommand<TestCommandOne, TestTopicSettings>));
+            var processorFoundTwo = provider.GetProcessor<TestCommandTwo>(typeof(IProcessCommand<TestCommandTwo, TestTopicSettings>));
+            //assert
+            processorFound.Should().Be(processor);
+            processorFoundTwo.Should().Be(processor);
+        }
+        [Test]
         public void Should_register_event_processor()
         {
             //arrange


### PR DESCRIPTION
Allow users to use KnightBus without any IoC framework. Just treat all message processors as singletons