### PR TITLE
Fix error message from exception in message handler. 

### DIFF
--- a/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
+++ b/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
@@ -10,7 +10,7 @@
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus-documentation/master/media/images/knighbus-64.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus/src/KnightBus.Host/MessageProcessor.cs
+++ b/knightbus/src/KnightBus.Host/MessageProcessor.cs
@@ -20,9 +20,8 @@ namespace KnightBus.Host
             var typedMessage = await messageStateHandler.GetMessageAsync().ConfigureAwait(false);
             var messageHandler = _processorProvider.GetProcessor<T>(typeof(TMessageProcessor));
 
-            await messageHandler.ProcessAsync(typedMessage, cancellationToken)
-                .ContinueWith(task => messageStateHandler.CompleteAsync(), TaskContinuationOptions.OnlyOnRanToCompletion)
-                .ConfigureAwait(false);
+            await messageHandler.ProcessAsync(typedMessage, cancellationToken).ConfigureAwait(false);
+            await messageStateHandler.CompleteAsync().ConfigureAwait(false);
         }
     }
 }

--- a/knightbus/tests/KnightBus.Host.Tests.Unit/Processors/MultipleCommandProcessor.cs
+++ b/knightbus/tests/KnightBus.Host.Tests.Unit/Processors/MultipleCommandProcessor.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using KnightBus.Core;
@@ -15,11 +14,11 @@ namespace KnightBus.Host.Tests.Unit.Processors
         {
             _countable = countable;
         }
-        public Task ProcessAsync(TestCommandOne message, CancellationToken cancellationToken)
+        public async Task ProcessAsync(TestCommandOne message, CancellationToken cancellationToken)
         {
             _countable.Count();
-            if (message.Throw) throw new Exception();
-            return Task.CompletedTask;
+            await Task.Delay(1, cancellationToken);
+            if (message.Throw) throw new TestException();
         }
 
         public Task ProcessAsync(TestCommandTwo message, CancellationToken cancellationToken)

--- a/knightbus/tests/KnightBus.Host.Tests.Unit/StandardMessagePipelineTests.cs
+++ b/knightbus/tests/KnightBus.Host.Tests.Unit/StandardMessagePipelineTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -76,7 +75,7 @@ namespace KnightBus.Host.Tests.Unit
             //act
             await _messageProcessor.ProcessAsync(_stateHandler.Object, CancellationToken.None);
             //assert
-            _stateHandler.Verify(x => x.AbandonByErrorAsync(It.IsAny<Exception>()), Times.Once);
+            _stateHandler.Verify(x => x.AbandonByErrorAsync(It.IsAny<TestException>()), Times.Once);
         }
 
         [Test]
@@ -89,9 +88,7 @@ namespace KnightBus.Host.Tests.Unit
             //act
             await _messageProcessor.ProcessAsync(_stateHandler.Object, CancellationToken.None);
             //assert
-            _logger.Verify(x => x.Error(It.IsAny<Exception>(), "Error processing message {@TestCommandOne}", It.IsAny<TestCommandOne>()), Times.Once);
+            _logger.Verify(x => x.Error(It.IsAny<TestException>(), "Error processing message {@TestCommandOne}", It.IsAny<TestCommandOne>()), Times.Once);
         }
-
-        
     }
 }

--- a/knightbus/tests/KnightBus.Host.Tests.Unit/TestException.cs
+++ b/knightbus/tests/KnightBus.Host.Tests.Unit/TestException.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace KnightBus.Host.Tests.Unit
+{
+    internal class TestException : Exception { }
+}


### PR DESCRIPTION
The ErrorHandlingMiddleware catches a TaskCanceledException that hijacks the true reason for a message being abandoned.