### PR TITLE
Added retry mechanism for ServiceBus

### DIFF
--- a/KnightBus.Azure.ServiceBus.Unit/KnightBus.Azure.ServiceBus.Unit.csproj
+++ b/KnightBus.Azure.ServiceBus.Unit/KnightBus.Azure.ServiceBus.Unit.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <ApplicationIcon />
+    <StartupObject />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0-preview-20190203-03" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\knightbus-azureservicebus\src\KnightBus.Azure.ServiceBus\KnightBus.Azure.ServiceBus.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/KnightBus.Azure.ServiceBus.Unit/ServiceBusTests.cs
+++ b/KnightBus.Azure.ServiceBus.Unit/ServiceBusTests.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using KnightBus.Azure.ServiceBus.Messages;
+using KnightBus.Messages;
+using Microsoft.Azure.ServiceBus;
+using Moq;
+using NUnit.Framework;
+
+namespace KnightBus.Azure.ServiceBus.Unit
+{
+    [TestFixture]
+    public class ServiceBusTests
+    {
+        [Test]
+        public void When_SendAsync_Throws_ServiceBusCommunicationException_Should_Retry_Three_Times()
+        {
+            var client = new Mock<IQueueClient>();
+            var clientFactory = new MockClientFactory(client.Object, Mock.Of<ITopicClient>());
+            client.Setup(c => c.SendAsync(It.IsAny<Message>())).Throws(new ServiceBusCommunicationException("Some communication error"));
+
+            var config = new Mock<IServiceBusConfiguration>();
+            config.Setup(c => c.MessageSerializer.Serialize(It.IsAny<IMessage>())).Returns(string.Empty);
+            var bus = new ServiceBus(config.Object) {ClientFactory = clientFactory};
+            Assert.ThrowsAsync<ServiceBusCommunicationException>(async () =>
+            {
+                await bus.SendAsync(new MockMessage());
+            });
+
+            // One call and 3 retries
+            client.Verify(c => c.SendAsync(It.IsAny<Message>()), Times.Exactly(3 + 1));
+        }
+
+        [Test]
+        public void When_SendBatchAsync_Throws_ServiceBusCommunicationException_Should_Retry_Three_Times()
+        {
+            var client = new Mock<IQueueClient>();
+            var clientFactory = new MockClientFactory(client.Object, Mock.Of<ITopicClient>());
+            client.Setup(c => c.SendAsync(It.IsAny<IList<Message>>())).Throws(new ServiceBusCommunicationException("Some communication error"));
+
+            var config = new Mock<IServiceBusConfiguration>();
+            config.Setup(c => c.MessageSerializer.Serialize(It.IsAny<IMessage>())).Returns(string.Empty);
+            var bus = new ServiceBus(config.Object) { ClientFactory = clientFactory };
+            Assert.ThrowsAsync<ServiceBusCommunicationException>(async () =>
+            {
+                IList<MockMessage> messages = new List<MockMessage> {new MockMessage()};
+                await bus.SendAsync(messages);
+            });
+
+            // One call and 3 retries
+            client.Verify(c => c.SendAsync(It.IsAny<IList<Message>>()), Times.Exactly(3 + 1));
+        }
+
+        [Test]
+        public void When_ScheduleAsync_Throws_ServiceBusCommunicationException_Should_Retry_Three_Times()
+        {
+            var client = new Mock<IQueueClient>();
+            var clientFactory = new MockClientFactory(client.Object, Mock.Of<ITopicClient>());
+            client.Setup(c => c.SendAsync(It.IsAny<Message>())).Throws(new ServiceBusCommunicationException("Some communication error"));
+
+            var config = new Mock<IServiceBusConfiguration>();
+            config.Setup(c => c.MessageSerializer.Serialize(It.IsAny<IMessage>())).Returns(string.Empty);
+            var bus = new ServiceBus(config.Object) { ClientFactory = clientFactory };
+            Assert.ThrowsAsync<ServiceBusCommunicationException>(async () =>
+            {
+                await bus.SendAsync(new MockMessage());
+            });
+
+            // One call and 3 retries
+            client.Verify(c => c.SendAsync(It.IsAny<Message>()), Times.Exactly(3 + 1));
+        }
+
+        [Test]
+        public void When_PublishAsync_Throws_ServiceBusCommunicationException_Should_Retry_Three_Times()
+        {
+            var client = new Mock<ITopicClient>();
+            var clientFactory = new MockClientFactory(Mock.Of<IQueueClient>(), client.Object);
+            client.Setup(c => c.SendAsync(It.IsAny<Message>())).Throws(new ServiceBusCommunicationException("Some communication error"));
+
+            var config = new Mock<IServiceBusConfiguration>();
+            config.Setup(c => c.MessageSerializer.Serialize(It.IsAny<IMessage>())).Returns(string.Empty);
+            var bus = new ServiceBus(config.Object) { ClientFactory = clientFactory };
+            Assert.ThrowsAsync<ServiceBusCommunicationException>(async () =>
+            {
+                await bus.PublishEventAsync(new MockEvent());
+            });
+
+            // One call and 3 retries
+            client.Verify(c => c.SendAsync(It.IsAny<Message>()), Times.Exactly(3 + 1));
+        }
+    }
+
+    public class MockClientFactory : IClientFactory
+    {
+        private readonly IQueueClient _queueClient;
+        private readonly ITopicClient _topicClient;
+
+        public MockClientFactory(IQueueClient queueClient, ITopicClient topicClient)
+        {
+            _queueClient = queueClient;
+            _topicClient = topicClient;
+        }
+
+        public Task<IQueueClient> GetQueueClient<T>() where T : ICommand
+        {
+            return Task.FromResult(_queueClient);
+        }
+
+        public Task<ITopicClient> GetTopicClient<T>() where T : IEvent
+        {
+            return Task.FromResult(_topicClient);
+        }
+
+        public Task<ISubscriptionClient> GetSubscriptionClient<TTopic, TSubscription>(TSubscription subscription) where TTopic : IEvent where TSubscription : IEventSubscription<TTopic>
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+
+    internal class MockMessage : IServiceBusCommand { }
+
+    internal class MockEvent : IServiceBusEvent { }
+}
+
+

--- a/KnightBus.sln
+++ b/KnightBus.sln
@@ -39,6 +39,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AzureServiceBus", "AzureSer
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AzureStorage", "AzureStorage", "{46D48336-73CC-4A9B-8B5F-14725D2AFFB4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KnightBus.Azure.ServiceBus.Unit", "KnightBus.Azure.ServiceBus.Unit\KnightBus.Azure.ServiceBus.Unit.csproj", "{B2075298-B4EE-4BD1-B541-D47C3E8A82D3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +103,10 @@ Global
 		{8D857EE4-99A6-491B-AC65-16403C0088D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8D857EE4-99A6-491B-AC65-16403C0088D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8D857EE4-99A6-491B-AC65-16403C0088D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2075298-B4EE-4BD1-B541-D47C3E8A82D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2075298-B4EE-4BD1-B541-D47C3E8A82D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2075298-B4EE-4BD1-B541-D47C3E8A82D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2075298-B4EE-4BD1-B541-D47C3E8A82D3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -115,6 +121,7 @@ Global
 		{8D857EE4-99A6-491B-AC65-16403C0088D3} = {1A7A20B2-65E7-4712-B93B-4AA3F73017A8}
 		{BFEEC811-DB77-4EF0-B43E-238FAF440E3A} = {60DD8989-3730-42B9-BD7B-3B38A6208FFB}
 		{46D48336-73CC-4A9B-8B5F-14725D2AFFB4} = {60DD8989-3730-42B9-BD7B-3B38A6208FFB}
+		{B2075298-B4EE-4BD1-B541-D47C3E8A82D3} = {BFEEC811-DB77-4EF0-B43E-238FAF440E3A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {14950A56-4265-429E-AF71-2D98B3B8AC48}

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ClientFactory.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ClientFactory.cs
@@ -1,51 +1,54 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using KnightBus.Core;
 using KnightBus.Messages;
 using Microsoft.Azure.ServiceBus;
 
+[assembly:InternalsVisibleTo("KnightBus.Azure.ServiceBus.Unit")]
+[assembly:InternalsVisibleTo("KnightBus.Azure.ServiceBus.Unit")]
 namespace KnightBus.Azure.ServiceBus
 {
     internal interface IClientFactory
     {
-        Task<QueueClient> GetQueueClient<T>() where T : ICommand;
-        Task<TopicClient> GetTopicClient<T>() where T : IEvent;
-        Task<SubscriptionClient> GetSubscriptionClient<TTopic, TSubscription>(TSubscription subscription) where TTopic : IEvent where TSubscription : IEventSubscription<TTopic>;
+        Task<IQueueClient> GetQueueClient<T>() where T : ICommand;
+        Task<ITopicClient> GetTopicClient<T>() where T : IEvent;
+        Task<ISubscriptionClient> GetSubscriptionClient<TTopic, TSubscription>(TSubscription subscription) where TTopic : IEvent where TSubscription : IEventSubscription<TTopic>;
     }
 
     internal class ClientFactory : IClientFactory
     {
         private readonly string _connectionString;
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
-        private ConcurrentDictionary<Type, QueueClient> QueueClients { get; } = new ConcurrentDictionary<Type, QueueClient>();
-        private ConcurrentDictionary<Type, TopicClient> TopicClients { get; } = new ConcurrentDictionary<Type, TopicClient>();
-        private ConcurrentDictionary<Type, SubscriptionClient> SubscriptionClients { get; } = new ConcurrentDictionary<Type, SubscriptionClient>();
+        private ConcurrentDictionary<Type, IQueueClient> QueueClients { get; } = new ConcurrentDictionary<Type, IQueueClient>();
+        private ConcurrentDictionary<Type, ITopicClient> TopicClients { get; } = new ConcurrentDictionary<Type, ITopicClient>();
+        private ConcurrentDictionary<Type, ISubscriptionClient> SubscriptionClients { get; } = new ConcurrentDictionary<Type, ISubscriptionClient>();
 
         public ClientFactory(string connectionString)
         {
             _connectionString = connectionString;
         }
 
-        private QueueClient CreateQueueClient<T>() where T : ICommand
+        private IQueueClient CreateQueueClient<T>() where T : ICommand
         {
             var queueName = AutoMessageMapper.GetQueueName<T>();
             return new QueueClient(_connectionString, queueName, ReceiveMode.PeekLock, RetryPolicy.Default);
         }
-        private TopicClient CreateTopicClient<T>() where T : IEvent
+        private ITopicClient CreateTopicClient<T>() where T : IEvent
         {
             var topicName = AutoMessageMapper.GetQueueName<T>();
             return new TopicClient(_connectionString, topicName, RetryPolicy.Default);
         }
 
-        private SubscriptionClient CreateSubscriptionClient<T>(string subscriptionName) where T : IEvent
+        private ISubscriptionClient CreateSubscriptionClient<T>(string subscriptionName) where T : IEvent
         {
             var topicName = AutoMessageMapper.GetQueueName<T>();
             return new SubscriptionClient(_connectionString, topicName, subscriptionName, ReceiveMode.PeekLock, RetryPolicy.Default);
         }
 
-        public async Task<QueueClient> GetQueueClient<T>() where T : ICommand
+        public async Task<IQueueClient> GetQueueClient<T>() where T : ICommand
         {
             if (QueueClients.TryGetValue(typeof(T), out var client))
             {
@@ -73,9 +76,9 @@ namespace KnightBus.Azure.ServiceBus
         }
 
 
-        public async Task<TopicClient> GetTopicClient<T>() where T : IEvent
+        public async Task<ITopicClient> GetTopicClient<T>() where T : IEvent
         {
-            if (TopicClients.TryGetValue(typeof(T), out TopicClient client))
+            if (TopicClients.TryGetValue(typeof(T), out ITopicClient client))
             {
                 return client;
             }
@@ -100,9 +103,9 @@ namespace KnightBus.Azure.ServiceBus
             }
         }
 
-        public async Task<SubscriptionClient> GetSubscriptionClient<TTopic, TSubscription>(TSubscription subscription) where TTopic : IEvent where TSubscription : IEventSubscription<TTopic>
+        public async Task<ISubscriptionClient> GetSubscriptionClient<TTopic, TSubscription>(TSubscription subscription) where TTopic : IEvent where TSubscription : IEventSubscription<TTopic>
         {
-            if (SubscriptionClients.TryGetValue(typeof(IEventSubscription<TTopic>), out SubscriptionClient client))
+            if (SubscriptionClients.TryGetValue(typeof(IEventSubscription<TTopic>), out ISubscriptionClient client))
             {
                 return client;
             }

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -10,7 +10,7 @@
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus-documentation/master/media/images/knighbus-64.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>2.0.1</Version>
+    <Version>2.1.0</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBus.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBus.cs
@@ -173,13 +173,8 @@ namespace KnightBus.Azure.ServiceBus
 
         private TimeSpan GetRetryDelay(int count)
         {
-            switch (count)
-            {
-                case 3: return TimeSpan.FromMilliseconds(300);
-                case 2: return TimeSpan.FromMilliseconds(600);
-                case 1: return TimeSpan.FromMilliseconds(900);
-                default: return TimeSpan.FromMilliseconds(300);
-            }
+            const int defaultRetryDelayInMilliseconds = 300;
+            return TimeSpan.FromMilliseconds(defaultRetryDelayInMilliseconds * count);
         }
     }
 }

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusQueueChannelReceiver.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusQueueChannelReceiver.cs
@@ -18,7 +18,7 @@ namespace KnightBus.Azure.ServiceBus
         private readonly ServiceBusConfiguration _configuration;
         private readonly IMessageProcessor _processor;
         private int _deadLetterLimit;
-        private QueueClient _client;
+        private IQueueClient _client;
         private readonly ManagementClient _managementClient;
 
         public ServiceBusQueueChannelReceiver(IProcessingSettings settings, ServiceBusConfiguration configuration, IHostConfiguration hostConfiguration, IMessageProcessor processor)

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusTopicChannelReceiver.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusTopicChannelReceiver.cs
@@ -18,7 +18,7 @@ namespace KnightBus.Azure.ServiceBus
         private readonly ServiceBusConfiguration _configuration;
         private readonly IMessageProcessor _processor;
         private int _deadLetterLimit;
-        private SubscriptionClient _client;
+        private ISubscriptionClient _client;
         
 
         public ServiceBusTopicChannelReceiver(IProcessingSettings settings, IEventSubscription<TTopic> subscription, ServiceBusConfiguration configuration, IHostConfiguration hostConfiguration, IMessageProcessor processor)


### PR DESCRIPTION
If we encounter a ServiceBusCommunicationException when communicating with Azure ServiceBus, we try to resend the message three times with a set interval.