### PR TITLE
Redis prefetch optimization

### DIFF
--- a/KnightBus.sln
+++ b/KnightBus.sln
@@ -63,6 +63,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KnightBus.Schedule.Tests.Un
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KnightBus.Azure.ServiceBus.Unit", "knightbus-azureservicebus\tests\KnightBus.Azure.ServiceBus.Unit\KnightBus.Azure.ServiceBus.Unit.csproj", "{22005970-5CAD-46B6-9CB8-4C6607D36944}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KnightBus.Redis.Tests.Integration", "knightbus-redis\tests\KnightBus.Redis.Tests.Integration\KnightBus.Redis.Tests.Integration.csproj", "{BD6A7EC2-E5A7-48C9-ADA4-0E3A824D8717}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KnightBus.Redis.Tests.Unit", "knightbus-redis\tests\KnightBus.Redis.Tests.Unit\KnightBus.Redis.Tests.Unit.csproj", "{495A52A9-3268-4744-BCD4-BEEECDD525F7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -169,6 +173,14 @@ Global
 		{22005970-5CAD-46B6-9CB8-4C6607D36944}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{22005970-5CAD-46B6-9CB8-4C6607D36944}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{22005970-5CAD-46B6-9CB8-4C6607D36944}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD6A7EC2-E5A7-48C9-ADA4-0E3A824D8717}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD6A7EC2-E5A7-48C9-ADA4-0E3A824D8717}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD6A7EC2-E5A7-48C9-ADA4-0E3A824D8717}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD6A7EC2-E5A7-48C9-ADA4-0E3A824D8717}.Release|Any CPU.Build.0 = Release|Any CPU
+		{495A52A9-3268-4744-BCD4-BEEECDD525F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{495A52A9-3268-4744-BCD4-BEEECDD525F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{495A52A9-3268-4744-BCD4-BEEECDD525F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{495A52A9-3268-4744-BCD4-BEEECDD525F7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -189,6 +201,8 @@ Global
 		{04087FF9-1A26-4230-807F-135E452453C3} = {1A7A20B2-65E7-4712-B93B-4AA3F73017A8}
 		{3BB50500-1F7C-44B0-9310-A5B1EE0A1E44} = {1A7A20B2-65E7-4712-B93B-4AA3F73017A8}
 		{22005970-5CAD-46B6-9CB8-4C6607D36944} = {BFEEC811-DB77-4EF0-B43E-238FAF440E3A}
+		{BD6A7EC2-E5A7-48C9-ADA4-0E3A824D8717} = {09D121DD-771E-478D-8E10-080D65929948}
+		{495A52A9-3268-4744-BCD4-BEEECDD525F7} = {09D121DD-771E-478D-8E10-080D65929948}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {14950A56-4265-429E-AF71-2D98B3B8AC48}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [Find the official KnightBus documentation here](https://knightbus.readthedocs.io/)
 
-<img src="https://raw.githubusercontent.com/BookBeat/knightbus-documentation/master/media/images/knightbus-logo.png" alt="KnightBus Logo" width="300"/>
+<img src="documentation/media/images/knightbus-logo.png" alt="KnightBus Logo" width="300"/>
 
 
 | Package | NuGet        |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 version: 2.0.{build}
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 services: 
-- mssql2014
+- mssql2017
 - docker
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 2.0.{build}
 
-image: Visual Studio 2019
+image: Visual Studio 2017
 
 services: 
 - mssql2014

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,19 @@
 version: 2.0.{build}
-image: Visual Studio 2017
-services: mssql2014
+
+image: Visual Studio 2019
+
+services: 
+- mssql2014
+- docker
+
 build_script:
 - cmd: >-
     dotnet build KnightBus.sln --configuration Release
+
+before_test:
+- docker pull redis
+- docker run -d -p 6379:6379 --name redis6379 redis
+
 test_script:
 - cmd: >-
     dotnet test knightbus/tests/KnightBus.Core.Tests.Unit/KnightBus.Core.Tests.Unit.csproj --logger:Appveyor
@@ -17,8 +27,14 @@ test_script:
     dotnet test knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/KnightBus.SqlServer.Tests.Integration.csproj --logger:Appveyor
     
     dotnet test knightbus-schedule/tests/KnightBus.Schedule.Tests.Unit/KnightBus.Schedule.Tests.Unit.csproj --logger:Appveyor
+
+    dotnet test knightbus-redis/tests/KnightBus.Redis.Tests.Unit/KnightBus.Redis.Tests.Unit.csproj --logger:Appveyor
+
+    dotnet test knightbus-redis/tests/KnightBus.Redis.Tests.Integration/KnightBus.Redis.Tests.Integration.csproj --logger:Appveyor
+
 artifacts:
 - path: '**\bin\Release\*.nupkg'
+
 deploy:
 - provider: NuGet
   api_key:

--- a/knightbus-redis/src/KnightBus.Redis/KnightBus.Redis.csproj
+++ b/knightbus-redis/src/KnightBus.Redis/KnightBus.Redis.csproj
@@ -10,7 +10,7 @@
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus-documentation/master/media/images/knighbus-64.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <PackageTags>knightbus;redis;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-redis/src/KnightBus.Redis/RedisChannelReceiver.cs
+++ b/knightbus-redis/src/KnightBus.Redis/RedisChannelReceiver.cs
@@ -81,12 +81,19 @@ namespace KnightBus.Redis
 
                 foreach (var redisMessage in messages)
                 {
-                    await _maxConcurrent.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    var cts = new CancellationTokenSource(_settings.MessageLockTimeout);
+                    if (redisMessage != null)
+                    {
+                        await _maxConcurrent.WaitAsync(cancellationToken).ConfigureAwait(false);
+                        var cts = new CancellationTokenSource(_settings.MessageLockTimeout);
 #pragma warning disable 4014
-                    Task.Run(async () => await ProcessMessageAsync(redisMessage, cts.Token)
-                        .ContinueWith(task2 => _maxConcurrent.Release(), cts.Token), cts.Token);
+                        Task.Run(async () => await ProcessMessageAsync(redisMessage, cts.Token)
+                            .ContinueWith(task2 => _maxConcurrent.Release(), cts.Token), cts.Token);
 #pragma warning restore 4014
+                    }
+                    else
+                    {
+                        return false;
+                    }
                 }
 
                 return true;

--- a/knightbus-redis/src/KnightBus.Redis/RedisManagementClient.cs
+++ b/knightbus-redis/src/KnightBus.Redis/RedisManagementClient.cs
@@ -20,16 +20,16 @@ namespace KnightBus.Redis
             _db = ConnectionMultiplexer.Connect(configuration.ConnectionString).GetDatabase(configuration.DatabaseId);
         }
 
-        public async Task<long> GetMessageCount<T>() where T : class, IRedisMessage
+        public Task<long> GetMessageCount<T>() where T : class, IRedisMessage
         {
             var queueClient = new RedisQueueClient<T>(_db);
-            return await queueClient.GetMessageCount();
+            return queueClient.GetMessageCount();
         }
 
-        public async Task<long> GetDeadletterMessageCount<T>() where T : class, IRedisMessage
+        public Task<long> GetDeadletterMessageCount<T>() where T : class, IRedisMessage
         {
             var queueClient = new RedisQueueClient<T>(_db);
-            return await queueClient.GetDeadletterMessageCount();
+            return queueClient.GetDeadletterMessageCount();
         }
 
         public async Task RequeueDeadLettersAsync<T>(long count) where T : class, IRedisMessage

--- a/knightbus-redis/src/KnightBus.Redis/RedisManagementClient.cs
+++ b/knightbus-redis/src/KnightBus.Redis/RedisManagementClient.cs
@@ -6,9 +6,9 @@ namespace KnightBus.Redis
 {
     public interface IRedisManagementClient
     {
-        Task<int> GetMessageCount<T>() where T : class, IRedisMessage;
-        Task<int> GetDeadletterMessageCount<T>() where T : class, IRedisMessage;
-        Task RequeueDeadLettersAsync<T>(int count) where T : class, IRedisMessage;
+        Task<long> GetMessageCount<T>() where T : class, IRedisMessage;
+        Task<long> GetDeadletterMessageCount<T>() where T : class, IRedisMessage;
+        Task RequeueDeadLettersAsync<T>(long count) where T : class, IRedisMessage;
     }
 
     public class RedisManagementClient : IRedisManagementClient
@@ -20,19 +20,19 @@ namespace KnightBus.Redis
             _db = ConnectionMultiplexer.Connect(configuration.ConnectionString).GetDatabase(configuration.DatabaseId);
         }
 
-        public async Task<int> GetMessageCount<T>() where T : class, IRedisMessage
+        public async Task<long> GetMessageCount<T>() where T : class, IRedisMessage
         {
             var queueClient = new RedisQueueClient<T>(_db);
             return await queueClient.GetMessageCount();
         }
 
-        public async Task<int> GetDeadletterMessageCount<T>() where T : class, IRedisMessage
+        public async Task<long> GetDeadletterMessageCount<T>() where T : class, IRedisMessage
         {
             var queueClient = new RedisQueueClient<T>(_db);
             return await queueClient.GetDeadletterMessageCount();
         }
 
-        public async Task RequeueDeadLettersAsync<T>(int count) where T : class, IRedisMessage
+        public async Task RequeueDeadLettersAsync<T>(long count) where T : class, IRedisMessage
         {
             var queueClient = new RedisQueueClient<T>(_db);
 

--- a/knightbus-redis/src/KnightBus.Redis/RedisQueueClient.cs
+++ b/knightbus-redis/src/KnightBus.Redis/RedisQueueClient.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using KnightBus.Core;
 using KnightBus.Redis.Messages;
 using StackExchange.Redis;
 
+[assembly: InternalsVisibleTo("KnightBus.Redis.Tests.Integration")]
+[assembly: InternalsVisibleTo("KnightBus.Redis.Tests.Unit")]
 namespace KnightBus.Redis
 {
     internal class RedisQueueClient<T> where T : class, IRedisMessage

--- a/knightbus-redis/src/KnightBus.Redis/RedisQueueClient.cs
+++ b/knightbus-redis/src/KnightBus.Redis/RedisQueueClient.cs
@@ -29,9 +29,9 @@ namespace KnightBus.Redis
             if (queueMessageCount < count)
                 count = (int)queueMessageCount;
 
-            var messages = new RedisMessage<T>[count];
             var cts = new CancellationTokenSource();
-            await Task.WhenAll(messages.Select(m => GetMessageAsync(cts))).ConfigureAwait(false);
+            var messages = await Task.WhenAll(Enumerable.Range(0, count).Select(i => GetMessageAsync(cts)))
+                .ConfigureAwait(false);
             return messages;
         }
 

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/KnightBus.Redis.Tests.Integration.csproj
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/KnightBus.Redis.Tests.Integration.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/KnightBus.Redis.Tests.Integration.csproj
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/KnightBus.Redis.Tests.Integration.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KnightBus.Redis\KnightBus.Redis.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/RedisQueueClientTests.cs
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/RedisQueueClientTests.cs
@@ -35,6 +35,10 @@ namespace KnightBus.Redis.Tests.Integration
             var command = new TestCommand(Guid.NewGuid().ToString());
             await _bus.SendAsync(command);
 
+            //Verify processing queue empty
+            var processingQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetProcessingQueueName(_queueName));
+            processingQueueLength.Should().Be(0);
+
             //Act
             var messages = await _target.GetMessagesAsync(5);
 
@@ -42,6 +46,12 @@ namespace KnightBus.Redis.Tests.Integration
             messages.Length.Should().Be(1);
             var message = messages.First();
             message.Message.Should().BeEquivalentTo(command);
+            message.ExpirationKey.Should().NotBeNullOrEmpty();
+            message.HashEntries.Should().ContainKey(RedisHashKeys.DeliveryCount);
+            var deliveryCount = message.HashEntries.First(e => e.Key.Equals(RedisHashKeys.DeliveryCount));
+            deliveryCount.Value.Should().Be("1");
+            processingQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetProcessingQueueName(_queueName));
+            processingQueueLength.Should().Be(1);
         }
 
         [Test]
@@ -49,24 +59,18 @@ namespace KnightBus.Redis.Tests.Integration
         {
             //Arrange
             var message = await SendAndGetMessage();
-            var hash = await Database.HashGetAllAsync(message.HashKey);
-            hash.Should().NotBeEmpty();
-            var expirationKey = await Database.StringGetAsync(message.ExpirationKey);
-            expirationKey.Should().NotBeNull();
-            var processingQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetProcessingQueueName(_queueName));
-            processingQueueLength.Should().Be(1);
 
             //Act
             await _target.CompleteMessageAsync(message);
 
             //Assert
-            hash = await Database.HashGetAllAsync(message.HashKey);
+            var hash = await Database.HashGetAllAsync(message.HashKey);
             hash.Should().BeEmpty();
-            expirationKey = await Database.StringGetAsync(message.ExpirationKey);
+            var expirationKey = await Database.StringGetAsync(message.ExpirationKey);
             expirationKey.HasValue.Should().BeFalse();
             var messages = await _target.GetMessagesAsync(1);
             messages.Length.Should().Be(0);
-            processingQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetProcessingQueueName(_queueName));
+            var processingQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetProcessingQueueName(_queueName));
             processingQueueLength.Should().Be(0);
         }
 
@@ -98,18 +102,14 @@ namespace KnightBus.Redis.Tests.Integration
         {
             //Arrange
             var message = await SendAndGetMessage();
-            var processingQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetProcessingQueueName(_queueName));
-            processingQueueLength.Should().Be(1);
-            var deadLetterQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetDeadLetterQueueName(_queueName));
-            deadLetterQueueLength.Should().Be(0);
 
             //Act
             await _target.DeadLetterMessageAsync(message, 1);
 
             //Assert
-            processingQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetProcessingQueueName(_queueName));
+            var processingQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetProcessingQueueName(_queueName));
             processingQueueLength.Should().Be(0);
-            deadLetterQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetDeadLetterQueueName(_queueName));
+            var deadLetterQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetDeadLetterQueueName(_queueName));
             deadLetterQueueLength.Should().Be(1);
         }
 
@@ -119,20 +119,15 @@ namespace KnightBus.Redis.Tests.Integration
             //Arrange
             var message = await SendAndGetMessage();
             await _target.DeadLetterMessageAsync(message, 1);
-            var deadLetterQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetDeadLetterQueueName(_queueName));
-            deadLetterQueueLength.Should().Be(1);
-            var hash = await Database.HashGetAllAsync(message.HashKey);
-            var deliveryCount = hash.First(h => h.Name.Equals(RedisHashKeys.DeliveryCount));
-            deliveryCount.Value.Should().Be(1);
 
             //Act
             await _target.RequeueDeadletterAsync();
 
             //Assert
-            deadLetterQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetDeadLetterQueueName(_queueName));
+            var deadLetterQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetDeadLetterQueueName(_queueName));
             deadLetterQueueLength.Should().Be(0);
-            hash = await Database.HashGetAllAsync(message.HashKey);
-            hash.Should().NotContain(h => h.Name.Equals(RedisHashKeys.DeliveryCount));
+            var queueLength = await Database.ListLengthAsync(_queueName);
+            queueLength.Should().Be(1);
         }
     }
 }

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/RedisQueueClientTests.cs
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/RedisQueueClientTests.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using KnightBus.Core;
+using NUnit.Framework;
+
+namespace KnightBus.Redis.Tests.Integration
+{
+    public class RedisQueueClientTests : RedisTestBase
+    {
+        private IRedisBus _bus;
+        private RedisQueueClient<TestCommand> _target;
+        private readonly string _queueName = AutoMessageMapper.GetQueueName<TestCommand>();
+
+        [SetUp]
+        public void Setup()
+        {
+            _bus = new RedisBus(Configuration);
+            _target = new RedisQueueClient<TestCommand>(Database);
+        }
+
+        private async Task<RedisMessage<TestCommand>> SendAndGetMessage()
+        {
+            var command = new TestCommand(Guid.NewGuid().ToString());
+            await _bus.SendAsync(command);
+            var messages = await _target.GetMessagesAsync(1);
+            return messages.First();
+        }
+
+        [Test]
+        public async Task GetMessagesAsync_should_get_messages()
+        {
+            //Arrange
+            var command = new TestCommand(Guid.NewGuid().ToString());
+            await _bus.SendAsync(command);
+
+            //Act
+            var messages = await _target.GetMessagesAsync(5);
+
+            //Assert
+            messages.Length.Should().Be(1);
+            var message = messages.First();
+            message.Message.Should().BeEquivalentTo(command);
+        }
+
+        [Test]
+        public async Task CompleteMessageAsync_should_delete_hash_and_expiration_keys_then_remove_message()
+        {
+            //Arrange
+            var message = await SendAndGetMessage();
+            var hash = await Database.HashGetAllAsync(message.HashKey);
+            hash.Should().NotBeEmpty();
+            var expirationKey = await Database.StringGetAsync(message.ExpirationKey);
+            expirationKey.Should().NotBeNull();
+            var processingQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetProcessingQueueName(_queueName));
+            processingQueueLength.Should().Be(1);
+
+            //Act
+            await _target.CompleteMessageAsync(message);
+
+            //Assert
+            hash = await Database.HashGetAllAsync(message.HashKey);
+            hash.Should().BeEmpty();
+            expirationKey = await Database.StringGetAsync(message.ExpirationKey);
+            expirationKey.HasValue.Should().BeFalse();
+            var messages = await _target.GetMessagesAsync(1);
+            messages.Length.Should().Be(0);
+            processingQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetProcessingQueueName(_queueName));
+            processingQueueLength.Should().Be(0);
+        }
+
+        [Test]
+        public async Task AbandonMessageByErrorAsync_should_requeue_message_and_set_error_hash()
+        {
+            //Arrange
+            var message = await SendAndGetMessage();
+            var exception = new Exception("Test exception");
+
+            //Act
+            await _target.AbandonMessageByErrorAsync(message, exception);
+
+            //Assert
+            var hash = await Database.HashGetAllAsync(message.HashKey);
+            var errors = hash.First(k => k.Name.Equals(RedisHashKeys.Errors));
+            var errorMessage = errors.Value.ToString().TrimEnd('\n');
+            errorMessage.Should().Be(exception.Message);
+
+            var reQueuedMessages = await _target.GetMessagesAsync(1);
+            var reQueuedMessage = reQueuedMessages.First();
+            reQueuedMessage.Message.Should().BeEquivalentTo(message.Message);
+            reQueuedMessage.HashKey.Should().BeEquivalentTo(message.HashKey);
+            reQueuedMessage.ExpirationKey.Should().BeEquivalentTo(message.ExpirationKey);
+        }
+
+        [Test]
+        public async Task DeadLetterMessageAsync_should_remove_from_processing_queue_and_put_message_in_deadletter_queue()
+        {
+            //Arrange
+            var message = await SendAndGetMessage();
+            var processingQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetProcessingQueueName(_queueName));
+            processingQueueLength.Should().Be(1);
+            var deadLetterQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetDeadLetterQueueName(_queueName));
+            deadLetterQueueLength.Should().Be(0);
+
+            //Act
+            await _target.DeadLetterMessageAsync(message, 1);
+
+            //Assert
+            processingQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetProcessingQueueName(_queueName));
+            processingQueueLength.Should().Be(0);
+            deadLetterQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetDeadLetterQueueName(_queueName));
+            deadLetterQueueLength.Should().Be(1);
+        }
+
+        [Test]
+        public async Task RequeueDeadletterAsync_should_requeue_message_remove_errors_and_delivery_count()
+        {
+            //Arrange
+            var message = await SendAndGetMessage();
+            await _target.DeadLetterMessageAsync(message, 1);
+            var deadLetterQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetDeadLetterQueueName(_queueName));
+            deadLetterQueueLength.Should().Be(1);
+            var hash = await Database.HashGetAllAsync(message.HashKey);
+            var deliveryCount = hash.First(h => h.Name.Equals(RedisHashKeys.DeliveryCount));
+            deliveryCount.Value.Should().Be(1);
+
+            //Act
+            await _target.RequeueDeadletterAsync();
+
+            //Assert
+            deadLetterQueueLength = await Database.ListLengthAsync(RedisQueueConventions.GetDeadLetterQueueName(_queueName));
+            deadLetterQueueLength.Should().Be(0);
+            hash = await Database.HashGetAllAsync(message.HashKey);
+            hash.Should().NotContain(h => h.Name.Equals(RedisHashKeys.DeliveryCount));
+        }
+    }
+}

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/RedisTestBase.cs
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/RedisTestBase.cs
@@ -11,7 +11,7 @@ namespace KnightBus.Redis.Tests.Integration
 
         private IConnectionMultiplexer _multiplexer;
 
-        [SetUp]
+        [OneTimeSetUp]
         public void BaseSetup()
         {
             Configuration = new RedisConfiguration("localhost:6379");
@@ -19,7 +19,7 @@ namespace KnightBus.Redis.Tests.Integration
             Database = _multiplexer.GetDatabase(Configuration.DatabaseId);
         }
 
-        [TearDown]
+        [TearDown] //This should be done after each test thus not OneTime
         public void BaseTeardown()
         {
             var server = _multiplexer.GetServer(Configuration.ConnectionString);

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/RedisTestBase.cs
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/RedisTestBase.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using StackExchange.Redis;
+
+namespace KnightBus.Redis.Tests.Integration
+{
+    [TestFixture]
+    public class RedisTestBase
+    {
+        protected RedisConfiguration Configuration;
+        protected IDatabase Database;
+
+        private IConnectionMultiplexer _multiplexer;
+
+        [SetUp]
+        public void BaseSetup()
+        {
+            Configuration = new RedisConfiguration("localhost:6379");
+            _multiplexer = ConnectionMultiplexer.Connect($"{Configuration.ConnectionString},allowAdmin=true");
+            Database = _multiplexer.GetDatabase(Configuration.DatabaseId);
+        }
+
+        [TearDown]
+        public void BaseTeardown()
+        {
+            var server = _multiplexer.GetServer(Configuration.ConnectionString);
+            server.FlushDatabase();
+        }
+    }
+}

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/TestCommand.cs
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/TestCommand.cs
@@ -1,0 +1,20 @@
+﻿using KnightBus.Messages;
+using KnightBus.Redis.Messages;
+
+namespace KnightBus.Redis.Tests.Integration
+{
+    public class TestCommand : IRedisCommand
+    {
+        public string Body { get; set; }
+
+        public TestCommand(string body)
+        {
+            Body = body;
+        }
+    }
+
+    public class TestCommandMapping : IMessageMapping<TestCommand>
+    {
+        public string QueueName => "test";
+    }
+}

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Unit/KnightBus.Redis.Tests.Unit.csproj
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Unit/KnightBus.Redis.Tests.Unit.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KnightBus.Redis\KnightBus.Redis.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Unit/KnightBus.Redis.Tests.Unit.csproj
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Unit/KnightBus.Redis.Tests.Unit.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="nunit" Version="3.12.0" />

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Unit/RedisQueueClientTests.cs
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Unit/RedisQueueClientTests.cs
@@ -1,0 +1,55 @@
+﻿using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using StackExchange.Redis;
+
+namespace KnightBus.Redis.Tests.Unit
+{
+    [TestFixture]
+    public class RedisQueueClientTests
+    {
+        private Mock<IDatabase> _db;
+        private RedisQueueClient<TestCommand> _target;
+
+        [SetUp]
+        public void Setup()
+        {
+            _db = new Mock<IDatabase>();
+            _target = new RedisQueueClient<TestCommand>(_db.Object);
+        }
+
+        [Test]
+        public async Task GetMessagesAsync_should_return_available_messages_when_there_are_messages()
+        {
+            //Arrange
+            const int messageCount = 5;
+            _db.Setup(x => x.ListLengthAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+                .ReturnsAsync(messageCount);
+
+            //Act
+            var messages = await _target.GetMessagesAsync(10);
+
+            //Assert
+            messages.Length.Should().Be(messageCount);
+            _db.Verify(d => d.ListRightPopLeftPushAsync(It.IsAny<RedisKey>(), It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()), Times.AtLeastOnce);
+        }
+
+        [Test]
+        public async Task GetMessagesAsync_should_not_try_to_fetch_messages_when_there_are_none()
+        {
+            //Arrange
+            const int messageCount = 0;
+            _db.Setup(d => d.ListLengthAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+                .ReturnsAsync(messageCount);
+
+            //Act
+            var messages = await _target.GetMessagesAsync(10);
+
+            //Assert
+            messages.Length.Should().Be(messageCount);
+            _db.Verify(d => d.ListLengthAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()), Times.Once);
+            _db.Verify(d => d.ListRightPopLeftPushAsync(It.IsAny<RedisKey>(), It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()), Times.Never);
+        }
+    }
+}

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Unit/TestCommand.cs
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Unit/TestCommand.cs
@@ -1,0 +1,20 @@
+﻿using KnightBus.Messages;
+using KnightBus.Redis.Messages;
+
+namespace KnightBus.Redis.Tests.Unit
+{
+    public class TestCommand : IRedisCommand
+    {
+        public string Body { get; set; }
+
+        public TestCommand(string body)
+        {
+            Body = body;
+        }
+    }
+
+    public class TestCommandMapping : IMessageMapping<TestCommand>
+    {
+        public string QueueName => "test";
+    }
+}

--- a/knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/DatabaseInitializer.cs
+++ b/knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/DatabaseInitializer.cs
@@ -7,8 +7,8 @@ namespace KnightBus.SqlServer.Tests.Integration
     public class DatabaseInitializer
     {
         private static string DatabaseName = "KnightBus";
-        public static readonly string ConnectionString = $@"Server=(local)\SQL2014;Database={DatabaseName};User ID=sa;Password=Password12!";
-        private const string AdminConnectionString = @"Server=(local)\SQL2014;Database=master;User ID=sa;Password=Password12!";
+        public static readonly string ConnectionString = $@"Server=(local)\SQL2017;Database={DatabaseName};User ID=sa;Password=Password12!";
+        private const string AdminConnectionString = @"Server=(local)\SQL2017;Database=master;User ID=sa;Password=Password12!";
 
         [OneTimeSetUp]
         public void Setup()

--- a/knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/DatabaseInitializer.cs
+++ b/knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/DatabaseInitializer.cs
@@ -6,7 +6,7 @@ namespace KnightBus.SqlServer.Tests.Integration
     [SetUpFixture]
     public class DatabaseInitializer
     {
-        private static string DatabaseName = "KnightBus";
+        private const string DatabaseName = "KnightBus";
         public static readonly string ConnectionString = $@"Server=(local)\SQL2017;Database={DatabaseName};User ID=sa;Password=Password12!";
         private const string AdminConnectionString = @"Server=(local)\SQL2017;Database=master;User ID=sa;Password=Password12!";
 
@@ -23,20 +23,5 @@ namespace KnightBus.SqlServer.Tests.Integration
                 command.ExecuteNonQuery();
             }
         }
-
-        [OneTimeTearDown]
-        public void Teardown()
-        {
-            using (var connection = new SqlConnection(AdminConnectionString))
-            {
-                connection.Open();
-                var sql = $@"
-                            IF DB_ID (N'{DatabaseName}') IS NOT NULL
-                            DROP DATABASE {DatabaseName};";
-                var command = new SqlCommand(sql, connection);
-                command.ExecuteNonQuery();
-            }
-        }
-
     }
 }


### PR DESCRIPTION
Add sanity check to verify that there are messages before prefetching and add CancellationTokenSource support for GetMessageAsync. 
Using ListLengthAsync instead of ListRangeAsync + length in GetMessageCount.