### PR TITLE
Ignore logging when exception is OperationCanceledException

### DIFF
--- a/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
+++ b/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>7.0.2</Version>
+    <Version>7.0.3</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/knightbus/src/KnightBus.Host/TcpAliveListenerPlugin.cs
+++ b/knightbus/src/KnightBus.Host/TcpAliveListenerPlugin.cs
@@ -50,7 +50,7 @@ namespace KnightBus.Host
                             {
                                 await stream.WriteAsync(msg, 0, msg.Length, cancellationToken).ConfigureAwait(false);
                             }
-                            catch (Exception e)
+                            catch (Exception e) when (!(e is OperationCanceledException))
                             {
                                 _log.Error(e, "Failed to write to stream");
                             }


### PR DESCRIPTION
We're seeing logs since graceful shutdown was introduced. This removes these, since it's expected behavior.