### PR TITLE
Skip logging that TcpAliveListenerPlugin crashed when catching expect…

### DIFF
--- a/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
+++ b/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>8.1.0</Version>
+    <Version>8.1.1</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/knightbus/src/KnightBus.Host/TcpAliveListenerPlugin.cs
+++ b/knightbus/src/KnightBus.Host/TcpAliveListenerPlugin.cs
@@ -59,7 +59,7 @@ namespace KnightBus.Host
                         }
                     }
                 }
-                catch (Exception e)
+                catch (Exception e) when (!(e is TaskCanceledException))
                 {
                     _log.Error(e, "TcpAliveListenerPlugin crashed");
                 }


### PR DESCRIPTION
…ed TaskCanceledException. Getting logs that the listener crashed but this isn't the case.