### PR TITLE
Feature/make work on dotnet core only machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ packages/
 
 # Ignore IDE folders
 .vscode/
+.idea
 
 # Ignore documentation build output generated VSCode
 _build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# CHANGELOG
+
+## 2020-11-06
+
+### KnightBus.SqlServer 6.0.0
+
+* (breaking) Dropped support for .NET461 as `<TargetFramework>`
+
+### KnightBus.Azure.ServiceBus 7.0.0
+
+* (breaking) Dropped support for .NET461 as `<TargetFramework>`
+
+### KnightBus.Host 9.0.0
+
+* (breaking) Dropped support for .NET461 as `<TargetFramework>`

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>6.1.0</Version>
+    <Version>7.0.0</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Azure Service Bus Transport for KnightBus</Description>

--- a/knightbus-azureservicebus/tests/KnightBus.Azure.ServiceBus.Unit/KnightBus.Azure.ServiceBus.Unit.csproj
+++ b/knightbus-azureservicebus/tests/KnightBus.Azure.ServiceBus.Unit/KnightBus.Azure.ServiceBus.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/KnightBus.Azure.Storage.Tests.Integration.csproj
+++ b/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/KnightBus.Azure.Storage.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Unit/ExtendMessageLockDurationMiddlewareTests.cs
+++ b/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Unit/ExtendMessageLockDurationMiddlewareTests.cs
@@ -7,6 +7,7 @@ using KnightBus.Core.DefaultMiddlewares;
 using KnightBus.Messages;
 using Moq;
 using NUnit.Framework;
+using Range = Moq.Range;
 
 namespace KnightBus.Azure.Storage.Tests.Unit
 {

--- a/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Unit/KnightBus.Azure.Storage.Tests.Unit.csproj
+++ b/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Unit/KnightBus.Azure.Storage.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/knightbus-schedule/tests/KnightBus.Schedule.Tests.Unit/KnightBus.Schedule.Tests.Unit.csproj
+++ b/knightbus-schedule/tests/KnightBus.Schedule.Tests.Unit/KnightBus.Schedule.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/knightbus-sqlserver/src/KnightBus.SqlServer/KnightBus.SqlServer.csproj
+++ b/knightbus-sqlserver/src/KnightBus.SqlServer/KnightBus.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Sql Server for KnightBus</Description>

--- a/knightbus-sqlserver/src/KnightBus.SqlServer/KnightBus.SqlServer.csproj
+++ b/knightbus-sqlserver/src/KnightBus.SqlServer/KnightBus.SqlServer.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>5.2.0</Version>
+    <Version>6.0.0</Version>
     <PackageTags>knightbus;sql;sql server;saga;</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/KnightBus.SqlServer.Tests.Integration.csproj
+++ b/knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/KnightBus.SqlServer.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/knightbus/examples/KnightBus.Examples.Azure.ServiceBus/KnightBus.Examples.Azure.ServiceBus.csproj
+++ b/knightbus/examples/KnightBus.Examples.Azure.ServiceBus/KnightBus.Examples.Azure.ServiceBus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/knightbus/examples/KnightBus.Examples.Azure.Storage/KnightBus.Examples.Azure.Storage.csproj
+++ b/knightbus/examples/KnightBus.Examples.Azure.Storage/KnightBus.Examples.Azure.Storage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/knightbus/examples/KnightBus.Examples.Redis/KnightBus.Examples.Redis.csproj
+++ b/knightbus/examples/KnightBus.Examples.Redis/KnightBus.Examples.Redis.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/knightbus/examples/KnightBus.Examples.Schedule/KnightBus.Examples.Schedule.csproj
+++ b/knightbus/examples/KnightBus.Examples.Schedule/KnightBus.Examples.Schedule.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
+++ b/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>8.4.1</Version>
+    <Version>9.0.0</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
+++ b/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>KnightBus Host</Description>

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/AutoMessageMapperTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/AutoMessageMapperTests.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace KnightBus.Core.Tests.Unit
 {
     [TestFixture]
-    public class MessageMapperTests
+    public class AutoMessageMapperTests
     {
         [Test]
         public void Should_throw_for_non_registered_message()

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/KnightBus.Core.Tests.Unit.csproj
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/KnightBus.Core.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/knightbus/tests/KnightBus.Host.Tests.Unit/KnightBus.Host.Tests.Unit.csproj
+++ b/knightbus/tests/KnightBus.Host.Tests.Unit/KnightBus.Host.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />


### PR DESCRIPTION
This PR fixes some chore stuff to make the project compile on a dotnetcore-only machine (namely, my own).

Also, since I didn't happen to have netcore2.x installed as SDK on my machine I took the liberty of updating all test projects to use netcoreapp3.1.