### PR TITLE
Bugfix/fix concurrency issue in message mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2020-11-09
+
+### KnightBus.Core
+
+* (bugfix) Register mappings from assembly before adding assembly to list of mapped assemblies. This solves a race condition where we would try to get a message mapping before it was mapped through the assembly.
+* (bugfix) Remove loop of types that had duplicate entries of IMessageMapping. This was due to an old auto-refactoring by Resharper.
+
 ## 2020-11-06
 
 ### KnightBus.SqlServer 6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2020-11-09
 
-### KnightBus.Core
+### KnightBus.Core 8.3.2
 
 * (bugfix) Register mappings from assembly before adding assembly to list of mapped assemblies. This solves a race condition where we would try to get a message mapping before it was mapped through the assembly.
 * (bugfix) Remove loop of types that had duplicate entries of IMessageMapping. This was due to an old auto-refactoring by Resharper.

--- a/knightbus/src/KnightBus.Core/AutoMessageMapper.cs
+++ b/knightbus/src/KnightBus.Core/AutoMessageMapper.cs
@@ -14,8 +14,8 @@ namespace KnightBus.Core
             var assembly = type.Assembly;
             if (AlreadyMappedAssemblies.ContainsKey(assembly.FullName)) return;
 
-            AlreadyMappedAssemblies.AddOrUpdate(assembly.FullName, false, (s, b) => b);
             MessageMapper.RegisterMappingsFromAssembly(assembly);
+            AlreadyMappedAssemblies.AddOrUpdate(assembly.FullName, false, (s, b) => b);
         }
 
         public static string GetQueueName(Type type)

--- a/knightbus/src/KnightBus.Core/AutoMessageMapper.cs
+++ b/knightbus/src/KnightBus.Core/AutoMessageMapper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using KnightBus.Core.Exceptions;
 using KnightBus.Messages;
 
@@ -8,14 +9,31 @@ namespace KnightBus.Core
     public static class AutoMessageMapper
     {
         private static readonly ConcurrentDictionary<string, bool> AlreadyMappedAssemblies = new ConcurrentDictionary<string, bool>();
+        private static readonly SemaphoreSlim Semaphore = new SemaphoreSlim(1,1);
 
         private static void MapFromMessageAssembly(Type type)
         {
             var assembly = type.Assembly;
             if (AlreadyMappedAssemblies.ContainsKey(assembly.FullName)) return;
 
-            MessageMapper.RegisterMappingsFromAssembly(assembly);
-            AlreadyMappedAssemblies.AddOrUpdate(assembly.FullName, false, (s, b) => b);
+            // This is so that we do not call RegisterMappingsFromAssembly twice for the same assembly.
+            // While the assembly is being scanned, it won't be in AlreadyMappedAssemblies, and
+            // we can't add it to AlreadyMappedAssemblies before it has finished scanning because
+            // that will give us a race condition and throw MessageMappingMissingException.
+            try
+            {
+                Semaphore.Wait();
+
+                // If the assembly was mapped while we were waiting for the semaphore to release, return
+                if (AlreadyMappedAssemblies.ContainsKey(assembly.FullName)) return;
+
+                MessageMapper.RegisterMappingsFromAssembly(assembly);
+                AlreadyMappedAssemblies.AddOrUpdate(assembly.FullName, false, (s, b) => b);
+            }
+            finally
+            {
+                Semaphore.Release();
+            }
         }
 
         public static string GetQueueName(Type type)

--- a/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
+++ b/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>8.3.1</Version>
+    <Version>8.3.2</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/MessageMapperTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/MessageMapperTests.cs
@@ -1,0 +1,56 @@
+using System;
+using FluentAssertions;
+using KnightBus.Core.Exceptions;
+using KnightBus.Messages;
+using NUnit.Framework;
+
+namespace KnightBus.Core.Tests.Unit
+{
+    [TestFixture]
+    public class MessageMapperTests
+    {
+        [Test]
+        public void Should_find_registered_mapping()
+        {
+            // align
+            const string name = "queue";
+            MessageMapper.RegisterMapping(typeof(RegisteredMessageMapping), name);
+
+            // act
+            var queueName = MessageMapper.GetQueueName(typeof(RegisteredMessageMapping));
+
+            // assert
+            queueName.Should().Be(name);
+        }
+
+        [Test]
+        public void Should_throw_for_non_registered_message()
+        {
+            var action = new Func<string>(() => MessageMapper.GetQueueName(typeof(NotRegisteredMessage)));
+            action.Invoking(m => m.Invoke()).Should().Throw<MessageMappingMissingException>();
+        }
+
+        [Test]
+        public void Should_map_assembly()
+        {
+            // align
+
+            // act
+            MessageMapper.RegisterMappingsFromAssembly(typeof(MessageMapperRegisteredCommand).Assembly);
+            var name = MessageMapper.GetQueueName(typeof(MessageMapperRegisteredCommand));
+
+            // assert
+            name.Should().Be("awesome-queue");
+        }
+        
+    }
+
+    public class MessageMapperRegisteredCommand : ICommand
+    {
+        public string MessageId { get; set; }
+    }
+    public class MessageMapperRegisteredCommandMapping : IMessageMapping<MessageMapperRegisteredCommand>
+    {
+        public string QueueName => "awesome-queue";
+    }
+}

--- a/knightbus/tests/KnightBus.Host.Tests.Unit/SingletonChannelReceiverTests.cs
+++ b/knightbus/tests/KnightBus.Host.Tests.Unit/SingletonChannelReceiverTests.cs
@@ -47,7 +47,7 @@ namespace KnightBus.Host.Tests.Unit
             //act
             await singletonChannelReceiver.StartAsync(CancellationToken.None);
             await singletonChannelReceiver.StartAsync(CancellationToken.None);
-            await Task.Delay(1500);
+            await Task.Delay(3000);
             //assert
             underlyingReceiver.Verify(x => x.StartAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
         }


### PR DESCRIPTION
This PR solves one issue and has one performance improvement.

The issue was that we could get a race condition when calling `AutoMessageMapper::GetQueueName(Type type)`, if the `type` was currently being processed - we would return and say that we had the mapping since it would exist in `AlreadyMappedAssemblies` before the processing of the assembly had completed.

The performance improvement is that we looped over the assembly twice in `MessageMapper::RegisterMappingsFromAssembly` due to an old auto-refactor by Resharper. We would loop over the assembly and look for types implementing `IMessageMapping` twice. Now it's only done once.