### PR TITLE
remove redundant calls to build ServiceProvider

### DIFF
--- a/knightbus-microsoft-dependencyinjection/src/KnightBus.Microsoft.DependencyInjection/MicrosoftDependencyInjection.cs
+++ b/knightbus-microsoft-dependencyinjection/src/KnightBus.Microsoft.DependencyInjection/MicrosoftDependencyInjection.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace KnightBus.Microsoft.DependencyInjection
 {
-    public class MicrosoftDependencyInjection : IIsolatedDependencyInjection
+    public class MicrosoftDependencyInjection : IDependencyInjection
     {
         private IServiceProvider _provider;
         private readonly IServiceCollection _serviceCollection;
@@ -58,12 +58,6 @@ namespace KnightBus.Microsoft.DependencyInjection
             foreach (var openImpl in ReflectionHelper.GetAllTypesImplementingOpenGenericInterface(openGeneric, assembly))
                 foreach (var openInterface in ReflectionHelper.GetAllInterfacesImplementingOpenGenericInterface(openImpl, openGeneric))
                     _serviceCollection.AddScoped(openInterface, openImpl);
-        }
-
-        public void Build()
-        {
-            if (_provider == null)
-                _provider = _serviceCollection.BuildServiceProvider(new ServiceProviderOptions {ValidateScopes = true});
         }
 
         public void Dispose()

--- a/knightbus/src/KnightBus.Core/IDependencyInjection.cs
+++ b/knightbus/src/KnightBus.Core/IDependencyInjection.cs
@@ -12,9 +12,4 @@ namespace KnightBus.Core
         IEnumerable<Type> GetOpenGenericRegistrations(Type openGeneric);
         void RegisterOpenGeneric(Type openGeneric, Assembly assembly);
     }
-
-    public interface IIsolatedDependencyInjection : IDependencyInjection
-    {
-        void Build();
-    }
 }

--- a/knightbus/src/KnightBus.Host/KnightBusHost.cs
+++ b/knightbus/src/KnightBus.Host/KnightBusHost.cs
@@ -44,9 +44,6 @@ namespace KnightBus.Host
             if(_configuration.DependencyInjection == null)
                 throw new DependencyInjectionMissingException();
 
-            if(_configuration.DependencyInjection is IIsolatedDependencyInjection isolated)
-                isolated.Build();
-                
             if (_transports.Any())
             {
                 _locator = new MessageProcessorLocator(_configuration, _transports.SelectMany(transport => transport.TransportChannelFactories).ToArray());


### PR DESCRIPTION
When using Microsoft Dependency Injection we accidentaly made a call to build our service provider when starting the host leaving us with two as IHostBuilder creates it's own when Building the host