### PR TITLE
Delete expiration when deleting deadletter

### DIFF
--- a/knightbus-redis/src/KnightBus.Redis/KnightBus.Redis.csproj
+++ b/knightbus-redis/src/KnightBus.Redis/KnightBus.Redis.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <PackageTags>knightbus;redis;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
We had forgotten about deleting the expiration when deleting deadletters.