### PR TITLE
Change IList<T> -> IEnumerable<T> for SendAsync

### DIFF
--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>12.2.1</Version>
+    <Version>12.3.0</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>12.3.0</Version>
+    <Version>13.0.0</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBus.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBus.cs
@@ -28,7 +28,7 @@ namespace KnightBus.Azure.ServiceBus
         /// <summary>
         /// Sends a batch of messages using the batch send method
         /// </summary>
-        Task SendAsync<T>(IList<T> messages, CancellationToken cancellationToken = default) where T : IServiceBusCommand;
+        Task SendAsync<T>(IEnumerable<T> messages, CancellationToken cancellationToken = default) where T : IServiceBusCommand;
 
         /// <summary>
         /// Sends a topic message immediately
@@ -64,10 +64,9 @@ namespace KnightBus.Azure.ServiceBus
             await SendAsync(client, sbMessage, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task SendAsync<T>(IList<T> messages, CancellationToken cancellationToken = default) where T : IServiceBusCommand
+        public async Task SendAsync<T>(IEnumerable<T> messages, CancellationToken cancellationToken = default) where T : IServiceBusCommand
         {
             var client = await ClientFactory.GetSenderClient<T>().ConfigureAwait(false);
-            if (!messages.Any()) return;
             var sbMessages = new List<ServiceBusMessage>();
             foreach (var message in messages)
             {
@@ -99,7 +98,7 @@ namespace KnightBus.Azure.ServiceBus
             await client.SendMessageAsync(message, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task SendAsync(ServiceBusSender client, IList<ServiceBusMessage> messages, CancellationToken cancellationToken)
+        private async Task SendAsync(ServiceBusSender client, IEnumerable<ServiceBusMessage> messages, CancellationToken cancellationToken)
         {
             await client.SendMessagesAsync(messages, cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
By changing signature of SendAsync from IList<T> to IEnumerable<T> we're making it easier for consumers to send large amount of messages without having to create numerous memory-consuming temporary arrays/lists to do so. 

```
public async Task SendStuff()
{
    foreach (var chunk in manyManyMessages.Chunk(50))
    {
        await _serviceBus.SendAsync(chunk.ToList(), ct);
    }
}
```
Can be simplified into this
```
public async Task SendStuff()
{
    foreach (var chunk in manyManyMessages.Chunk(50))
    {
        await _serviceBus.SendAsync(chunk, ct);
    }
}
```
The only reason we've used IList<T> before is to avoid multiple enumerations because we returned if the IList<T> contained no items. 
```
public async Task SendAsync<T>(IList<T> messages, CancellationToken cancellationToken = default) where T : IServiceBusCommand
{
    var client = await ClientFactory.GetSenderClient<T>().ConfigureAwait(false);
    if (!messages.Any()) return;
    var sbMessages = new List<ServiceBusMessage>();
    foreach (var message in messages)
    {
        sbMessages.Add(await CreateMessageAsync(message).ConfigureAwait(false));
    }

    await SendAsync(client, sbMessages, cancellationToken).ConfigureAwait(false);
}
```
However, looking into the ServiceBus method we're using to send messages on, we can see that this is already handled by the framework.
```
public virtual async Task SendMessagesAsync(
    IEnumerable<ServiceBusMessage> messages,
    CancellationToken cancellationToken = default)
{
    Argument.AssertNotNull(messages, nameof(messages));
    Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSender));
    IReadOnlyList<ServiceBusMessage> messageList = messages switch
    {
        IReadOnlyList<ServiceBusMessage> alreadyList => alreadyList,
        _ => messages.ToList()
    };

    if (messageList.Count == 0)
    {
        return;
    }

    ...
    ...
}
```
Meaning us not asserting if the list is empty has no drawbacks and will not cause potential exceptions. 