### PR TITLE
Improve message batch support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 * Use Service Bus internal framework for making sure batches of messages do not exceed maximum batch size
 
-### KnightBus.Core 10.2.0
-
-* Add `ServiceBusMessageTooLargeException`
-
 ### KnightBus.Azure.ServiceBus 13.0.0
 
 * Change IList<T> -> IEnumerable<T> for SendAsync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## 2021-05-03
+
+### KnightBus.Azure.ServiceBus 13.1.0
+
+* Use Service Bus internal framework for making sure batches of messages do not exceed maximum batch size
+
+### KnightBus.Core 10.2.0
+
+* Add `ServiceBusMessageTooLargeException`
+
+### KnightBus.Azure.ServiceBus 13.0.0
+
+* Change IList<T> -> IEnumerable<T> for SendAsync
+
 ## 2021-04-06
 
 ### KnightBus.Core 9.0.0

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>13.0.0</Version>
+    <Version>13.1.0</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusMessageTooLargeException.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusMessageTooLargeException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace KnightBus.Core.Exceptions
+namespace KnightBus.Azure.ServiceBus
 {
     public sealed class ServiceBusMessageTooLargeException : Exception
     {

--- a/knightbus/src/KnightBus.Core/Exceptions/ServiceBusMessageTooLargeException.cs
+++ b/knightbus/src/KnightBus.Core/Exceptions/ServiceBusMessageTooLargeException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace KnightBus.Core.Exceptions
+{
+    public sealed class ServiceBusMessageTooLargeException : Exception
+    {
+    }
+}

--- a/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
+++ b/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>10.2.0</Version>
+    <Version>10.1.0</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
+++ b/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>10.1.1</Version>
+    <Version>10.2.0</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
Instead of letting every consumer have knowledge of how many messages can be sent to the service bus, let the serice bus framework make sure maximum size is not exceeded.

Microsoft documentation for batch: https://docs.microsoft.com/en-us/dotnet/api/overview/azure/messaging.servicebus-readme?view=azure-dotnet#send-and-receive-a-batch-of-messages