### PR TITLE
Event batch support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2021-05-04
+
+### KnightBus.Azure.ServiceBus 13.2.0
+
+* Add batch `PublishEventsAsync<T>(IEnumerable<T>, CancellationToken)`
+
 ## 2021-05-03
 
 ### KnightBus.Azure.ServiceBus 13.1.0

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>13.1.0</Version>
+    <Version>13.2.0</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
Now that we use Service Bus internal out-of-the-box mechanism for batching messages, we should offer consumers the option to also send events as batches. 