### PR TITLE
Target net6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,85 @@
 # CHANGELOG
 
+## 2021-12-21
+
+### KnightBus.SqlServer 9.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.SimpleInjector 11.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Serilog 9.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Schedule 8.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.ProtobufNet 3.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Netwonsoft 2.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.NewRelic 5.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Microsoft.DependencyInjection 11.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Messages 5.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.MessagePack 2.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Host 12.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Core 11.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.ApplicationInsights 8.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Redis.Messages 4.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Redis 7.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Azure.Storage.Messages 4.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Azure.Storage 11.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Azure.ServiceBus.Messages 4.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### KnightBus.Azure.ServiceBus 14.0.0
+
+* Change target framework from net5.0 -> net6.0
+
+### 
+
 ## 2021-05-05
 
 ### KnightBus.Azure.ServiceBus 13.3.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 2.0.{build}
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 services: 
 - mssql2017

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,10 @@ version: 2.0.{build}
 image: Visual Studio 2022
 
 services: 
-- mssql2017
 - docker
+
+init:
+- net start MSSQL$SQL2019
 
 build_script:
 - cmd: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,13 +10,12 @@ init:
 
 build_script:
 - cmd: >-
-    "C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
-
     dotnet build KnightBus.sln --configuration Release
 
 before_test:
 - docker pull redis
 - docker run -d -p 6379:6379 --name redis6379 redis
+- docker run -d -p 10000:10000 mcr.microsoft.com/azure-storage/azurite
 
 test_script:
 - cmd: >-

--- a/knightbus-applicationinsights/src/KnightBus.ApplicationInsights/KnightBus.ApplicationInsights.csproj
+++ b/knightbus-applicationinsights/src/KnightBus.ApplicationInsights/KnightBus.ApplicationInsights.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Application Insights for KnightBus</Description>
-    <Copyright>Copyright © BookBeat 2018</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>7.1.1</Version>
+    <Version>8.0.0</Version>
     <PackageTags>knightbus;applicationinsights;azure;</PackageTags>
   </PropertyGroup>
 
@@ -19,8 +19,8 @@
     <None Include="knighbus-64.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.17.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.17.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.20.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.20.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus.Messages/KnightBus.Azure.ServiceBus.Messages.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus.Messages/KnightBus.Azure.ServiceBus.Messages.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Azure Service Bus Messages for KnightBus</Description>
-    <Copyright>Copyright © BookBeat 2018</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>3.1.1</Version>
+    <Version>4.0.0</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Azure Service Bus Transport for KnightBus</Description>
-    <Copyright>Copyright © BookBeat 2019</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>13.4.0</Version>
+    <Version>14.0.0</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.2.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="knighbus-64.png" Pack="true" Visible="false" PackagePath="" />

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage.Messages/KnightBus.Azure.Storage.Messages.csproj
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage.Messages/KnightBus.Azure.Storage.Messages.csproj
@@ -5,13 +5,13 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Azure Storage Messages for KnightBus</Description>
-    <Copyright>Copyright © BookBeat 2018</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>3.1.1</Version>  
+    <Version>4.0.0</Version>  
     <PackageTags>knightbus;azure storage;blob;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage.Messages/KnightBus.Azure.Storage.Messages.csproj
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage.Messages/KnightBus.Azure.Storage.Messages.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Azure Storage Messages for KnightBus</Description>

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage/KnightBus.Azure.Storage.csproj
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage/KnightBus.Azure.Storage.csproj
@@ -5,12 +5,12 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Azure Storage Transport for KnightBus</Description>
-    <Copyright>Copyright © BookBeat 2018</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>10.3.0</Version>
+    <Version>11.0.0</Version>
     <PackageTags>knightbus;azure storage;blob;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage/KnightBus.Azure.Storage.csproj
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage/KnightBus.Azure.Storage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Azure Storage Transport for KnightBus</Description>

--- a/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/BlobLockManagerTests.cs
+++ b/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/BlobLockManagerTests.cs
@@ -92,7 +92,10 @@ namespace KnightBus.Azure.Storage.Tests.Integration
             await Task.Delay(TimeSpan.FromSeconds(16));
             //steal lock
             await lockManager.TryLockAsync(lockId, TimeSpan.FromSeconds(15), CancellationToken.None);
-            handle.Awaiting(x=> x.RenewAsync(Mock.Of<ILog>(), CancellationToken.None)).Should().ThrowAsync<RequestFailedException>();
+            await handle
+                .Awaiting(x=> x.RenewAsync(Mock.Of<ILog>(), CancellationToken.None))
+                .Should()
+                .ThrowAsync<RequestFailedException>();
         }
     }
 }

--- a/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/BlobLockManagerTests.cs
+++ b/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/BlobLockManagerTests.cs
@@ -92,7 +92,7 @@ namespace KnightBus.Azure.Storage.Tests.Integration
             await Task.Delay(TimeSpan.FromSeconds(16));
             //steal lock
             await lockManager.TryLockAsync(lockId, TimeSpan.FromSeconds(15), CancellationToken.None);
-            handle.Awaiting(x=> x.RenewAsync(Mock.Of<ILog>(), CancellationToken.None)).Should().Throw<RequestFailedException>();
+            handle.Awaiting(x=> x.RenewAsync(Mock.Of<ILog>(), CancellationToken.None)).Should().ThrowAsync<RequestFailedException>();
         }
     }
 }

--- a/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/KnightBus.Azure.Storage.Tests.Integration.csproj
+++ b/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/KnightBus.Azure.Storage.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/KnightBus.Azure.Storage.Tests.Integration.csproj
+++ b/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/KnightBus.Azure.Storage.Tests.Integration.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\knightbus\tests\KnightBus.Shared.Tests.Integration\KnightBus.Shared.Tests.Integration.csproj" />

--- a/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Unit/KnightBus.Azure.Storage.Tests.Unit.csproj
+++ b/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Unit/KnightBus.Azure.Storage.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Unit/KnightBus.Azure.Storage.Tests.Unit.csproj
+++ b/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Unit/KnightBus.Azure.Storage.Tests.Unit.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\KnightBus.Azure.Storage\KnightBus.Azure.Storage.csproj" />

--- a/knightbus-messagepack/src/KnightBus.MessagePack/KnightBus.MessagePack.csproj
+++ b/knightbus-messagepack/src/KnightBus.MessagePack/KnightBus.MessagePack.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Messagepack serialization for KnightBus</Description>
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>1.0.1</Version>
+    <Version>2.0.0</Version>
     <PackageTags>knightbus;msgpack;messagepack</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.2.85" />
+    <PackageReference Include="MessagePack" Version="2.3.85" />
   </ItemGroup>
 
   <ItemGroup>

--- a/knightbus-microsoft-dependencyinjection/src/KnightBus.Microsoft.DependencyInjection/KnightBus.Microsoft.DependencyInjection.csproj
+++ b/knightbus-microsoft-dependencyinjection/src/KnightBus.Microsoft.DependencyInjection/KnightBus.Microsoft.DependencyInjection.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Microsoft.Extensions.DependencyInjection IoC for KnightBus</Description>
-    <Copyright>Copyright © BookBeat 2018</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>10.2.0</Version>
+    <Version>11.0.0</Version>
     <PackageTags>knightbus;microsoft.extensions.dependencyinjection;ioc;</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="knighbus-64.png" Pack="true" Visible="false" PackagePath="" />

--- a/knightbus-newrelic/src/KnightBus.NewRelic/KnightBus.NewRelic.csproj
+++ b/knightbus-newrelic/src/KnightBus.NewRelic/KnightBus.NewRelic.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <RootNamespace>KnightBus.NewRelicMiddleware</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>NewRelic.Agent.Api for KnightBus</Description>
-    <Copyright>Copyright © BookBeat 2020</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>4.1.1</Version>
+    <Version>5.0.0</Version>
     <PackageTags>knightbus;apm;newrelic.agent.api</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <None Include="knighbus-64.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.39.1" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="9.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/knightbus-newtonsoft/src/KnightBus.Newtonsoft/KnightBus.Newtonsoft.csproj
+++ b/knightbus-newtonsoft/src/KnightBus.Newtonsoft/KnightBus.Newtonsoft.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>BookBeat</Authors>
         <Description>Json.Net serialization for KnightBus</Description>
@@ -11,7 +11,7 @@
         <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
         <PackageIcon>knighbus-64.png</PackageIcon>
         <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-        <Version>1.1.0</Version>
+        <Version>2.0.0</Version>
         <PackageTags>knightbus;json.net;newtonsoft</PackageTags>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/knightbus-protobuf-net/src/KnightBus.ProtoBufNet/KnightBus.ProtoBufNet.csproj
+++ b/knightbus-protobuf-net/src/KnightBus.ProtoBufNet/KnightBus.ProtoBufNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Protobuf serialization for KnightBus</Description>
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>2.1.1</Version>
+    <Version>3.0.0</Version>
     <PackageTags>knightbus;grpc;protobuf</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/knightbus-redis/src/KnightBus.Redis.Messages/KnightBus.Redis.Messages.csproj
+++ b/knightbus-redis/src/KnightBus.Redis.Messages/KnightBus.Redis.Messages.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Redis Messages for KnightBus</Description>
-    <Copyright>Copyright © BookBeat 2019</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>3.1.1</Version>
+    <Version>4.0.0</Version>
     <PackageTags>knightbus;redis;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/knightbus-redis/src/KnightBus.Redis/KnightBus.Redis.csproj
+++ b/knightbus-redis/src/KnightBus.Redis/KnightBus.Redis.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Redis Transport for KnightBus</Description>
-    <Copyright>Copyright © BookBeat 2018</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>6.2.2</Version>
+    <Version>7.0.0</Version>
     <PackageTags>knightbus;redis;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.2.79" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.88" />
   </ItemGroup>
   <ItemGroup>
     <None Include="knighbus-64.png" Pack="true" Visible="false" PackagePath="" />

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/KnightBus.Redis.Tests.Integration.csproj
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/KnightBus.Redis.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/KnightBus.Redis.Tests.Integration.csproj
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Integration/KnightBus.Redis.Tests.Integration.csproj
@@ -8,15 +8,15 @@
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-    <PackageReference Include="System.Linq.Async" Version="4.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Unit/KnightBus.Redis.Tests.Unit.csproj
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Unit/KnightBus.Redis.Tests.Unit.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/knightbus-redis/tests/KnightBus.Redis.Tests.Unit/KnightBus.Redis.Tests.Unit.csproj
+++ b/knightbus-redis/tests/KnightBus.Redis.Tests.Unit/KnightBus.Redis.Tests.Unit.csproj
@@ -8,14 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/knightbus-schedule/src/KnightBus.Schedule/KnightBus.Schedule.csproj
+++ b/knightbus-schedule/src/KnightBus.Schedule/KnightBus.Schedule.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>KnightBus Chron Scheduler</Description>
-    <Copyright>Copyright © BookBeat 2018</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>7.0.0</Version>
+    <Version>8.0.0</Version>
     <PackageTags>knightbus;quartz;schedule;trigger</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/knightbus-schedule/tests/KnightBus.Schedule.Tests.Unit/KnightBus.Schedule.Tests.Unit.csproj
+++ b/knightbus-schedule/tests/KnightBus.Schedule.Tests.Unit/KnightBus.Schedule.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/knightbus-schedule/tests/KnightBus.Schedule.Tests.Unit/KnightBus.Schedule.Tests.Unit.csproj
+++ b/knightbus-schedule/tests/KnightBus.Schedule.Tests.Unit/KnightBus.Schedule.Tests.Unit.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\KnightBus.Schedule\KnightBus.Schedule.csproj" />

--- a/knightbus-serilog/src/KnightBus.Serilog/KnightBus.Serilog.csproj
+++ b/knightbus-serilog/src/KnightBus.Serilog/KnightBus.Serilog.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Serilog for KnightBus</Description>
-    <Copyright>Copyright © BookBeat 2018</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>8.1.1</Version>
+    <Version>9.0.0</Version>
     <PackageTags>knightbus;serilog;</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/knightbus-simpleinjector/src/KnightBus.SimpleInjector/KnightBus.SimpleInjector.csproj
+++ b/knightbus-simpleinjector/src/KnightBus.SimpleInjector/KnightBus.SimpleInjector.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>SimpleInjector IoC for KnightBus</Description>
-    <Copyright>Copyright © BookBeat 2020</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>10.1.1</Version>
+    <Version>11.0.0</Version>
     <PackageTags>knightbus;simpleinjector;ioc;</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <None Include="knighbus-64.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SimpleInjector" Version="5.3.0" />
+    <PackageReference Include="SimpleInjector" Version="5.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/knightbus-sqlserver/src/KnightBus.SqlServer/KnightBus.SqlServer.csproj
+++ b/knightbus-sqlserver/src/KnightBus.SqlServer/KnightBus.SqlServer.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Sql Server for KnightBus</Description>
-    <Copyright>Copyright © BookBeat 2019</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>8.1.1</Version>
+    <Version>9.0.0</Version>
     <PackageTags>knightbus;sql;sql server;saga;</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <None Include="knighbus-64.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/DatabaseInitializer.cs
+++ b/knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/DatabaseInitializer.cs
@@ -7,8 +7,8 @@ namespace KnightBus.SqlServer.Tests.Integration
     public class DatabaseInitializer
     {
         private const string DatabaseName = "KnightBus";
-        public static readonly string ConnectionString = $@"Server=(local)\SQL2017;Database={DatabaseName};User ID=sa;Password=Password12!";
-        private const string AdminConnectionString = @"Server=(local)\SQL2017;Database=master;User ID=sa;Password=Password12!";
+        public static readonly string ConnectionString = $@"Server=(local)\SQL2019;Database={DatabaseName};User ID=sa;Password=Password12!";
+        private const string AdminConnectionString = @"Server=(local)\SQL2019;Database=master;User ID=sa;Password=Password12!";
 
         [OneTimeSetUp]
         public void Setup()

--- a/knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/KnightBus.SqlServer.Tests.Integration.csproj
+++ b/knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/KnightBus.SqlServer.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/KnightBus.SqlServer.Tests.Integration.csproj
+++ b/knightbus-sqlserver/tests/KnightBus.SqlServer.Tests.Integration/KnightBus.SqlServer.Tests.Integration.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\knightbus\tests\KnightBus.Shared.Tests.Integration\KnightBus.Shared.Tests.Integration.csproj" />

--- a/knightbus/examples/KnightBus.Examples.Azure.ServiceBus/KnightBus.Examples.Azure.ServiceBus.csproj
+++ b/knightbus/examples/KnightBus.Examples.Azure.ServiceBus/KnightBus.Examples.Azure.ServiceBus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/knightbus/examples/KnightBus.Examples.Azure.Storage/KnightBus.Examples.Azure.Storage.csproj
+++ b/knightbus/examples/KnightBus.Examples.Azure.Storage/KnightBus.Examples.Azure.Storage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/knightbus/examples/KnightBus.Examples.Redis/KnightBus.Examples.Redis.csproj
+++ b/knightbus/examples/KnightBus.Examples.Redis/KnightBus.Examples.Redis.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/knightbus/examples/KnightBus.Examples.Schedule/KnightBus.Examples.Schedule.csproj
+++ b/knightbus/examples/KnightBus.Examples.Schedule/KnightBus.Examples.Schedule.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
+++ b/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Shared core functionallity for the KnightBus framework</Description>
-    <Copyright>Copyright © BookBeat 2020</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>10.1.0</Version>
+    <Version>11.0.0</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -19,7 +19,7 @@
     <None Include="knighbus-64.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
+++ b/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>KnightBus Host</Description>
-    <Copyright>Copyright © BookBeat 2020</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>11.2.0</Version>
+    <Version>12.0.0</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <None Include="knighbus-64.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\KnightBus.Core\KnightBus.Core.csproj" />

--- a/knightbus/src/KnightBus.Messages/KnightBus.Messages.csproj
+++ b/knightbus/src/KnightBus.Messages/KnightBus.Messages.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>BookBeat</Authors>
     <Description>Base KnightBus Message Interfaces</Description>
-    <Copyright>Copyright © BookBeat 2018</Copyright>
+    <Copyright>Copyright © BookBeat 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://knightbus.readthedocs.io</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>4.0.1</Version>
+    <Version>5.0.0</Version>
     <PackageTags>knightbus;messaging;</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/ErrorHandlingMiddlewareTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/ErrorHandlingMiddlewareTests.cs
@@ -22,7 +22,7 @@ namespace KnightBus.Core.Tests.Unit
             var logger = new Mock<ILog>();
             var middleware = new ErrorHandlingMiddleware(logger.Object);
             //act & assert
-            middleware.Invoking(async x=> await x.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, CancellationToken.None)).Should().NotThrow();
+            middleware.Invoking(async x=> await x.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, CancellationToken.None)).Should().NotThrowAsync();
             
         }
 
@@ -69,7 +69,7 @@ namespace KnightBus.Core.Tests.Unit
             var logger = new Mock<ILog>();
             var middleware = new ErrorHandlingMiddleware(logger.Object);
             //act
-            middleware.Invoking(async x => await x.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, CancellationToken.None)).Should().NotThrow();
+            middleware.Invoking(async x => await x.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, CancellationToken.None)).Should().NotThrowAsync();
             //assert
             logger.Verify(x => x.Error(It.IsAny<Exception>(), "Failed to abandon message {@TestCommand}", It.IsAny<TestCommand>()), Times.Once);
         }

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/KnightBus.Core.Tests.Unit.csproj
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/KnightBus.Core.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/KnightBus.Core.Tests.Unit.csproj
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/KnightBus.Core.Tests.Unit.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\knightbus-messagepack\src\KnightBus.MessagePack\KnightBus.MessagePack.csproj" />

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/SagaHandlerTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/SagaHandlerTests.cs
@@ -43,7 +43,7 @@ namespace KnightBus.Core.Tests.Unit
         }
 
         [Test]
-        public void Initialize_should_throw_when_message_is_not_mapped()
+        public async Task Initialize_should_throw_when_message_is_not_mapped()
         {
             //arrange
             var id = "something-unique";
@@ -52,7 +52,10 @@ namespace KnightBus.Core.Tests.Unit
             var startMessage = new TestSagaMessage(id);
             var handler = new SagaHandler<TestSagaData, TestSagaMessage>(store.Object, saga, startMessage);
             //act & assert
-            handler.Awaiting(x => x.Initialize()).Should().ThrowAsync<SagaMessageMappingNotFoundException>();
+            await handler
+                .Awaiting(x => x.Initialize())
+                .Should()
+                .ThrowAsync<SagaMessageMappingNotFoundException>();
         }
 
         internal class TestSagaData

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/SagaHandlerTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/SagaHandlerTests.cs
@@ -52,7 +52,7 @@ namespace KnightBus.Core.Tests.Unit
             var startMessage = new TestSagaMessage(id);
             var handler = new SagaHandler<TestSagaData, TestSagaMessage>(store.Object, saga, startMessage);
             //act & assert
-            handler.Awaiting(x => x.Initialize()).Should().Throw<SagaMessageMappingNotFoundException>();
+            handler.Awaiting(x => x.Initialize()).Should().ThrowAsync<SagaMessageMappingNotFoundException>();
         }
 
         internal class TestSagaData

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/SagaMiddlewareTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/SagaMiddlewareTests.cs
@@ -76,7 +76,7 @@ namespace KnightBus.Core.Tests.Unit
         }
 
         [Test]
-        public void If_Saga_implements_ISagaDuplicateDetected_then_ProcessDuplicateAsync_throws_then_Exception_should_be_thrown()
+        public async Task If_Saga_implements_ISagaDuplicateDetected_then_ProcessDuplicateAsync_throws_then_Exception_should_be_thrown()
         {
             //arrange
             var partitionKey = "a";
@@ -101,8 +101,10 @@ namespace KnightBus.Core.Tests.Unit
             var middleware = new SagaMiddleware(sagaStore.Object);
 
             //act
-            middleware.Awaiting(x=> x.ProcessAsync(messageStateHandler.Object, pipelineInformation.Object, null, CancellationToken.None))
-                .Should().ThrowAsync<ApplicationException>();
+            await middleware
+                .Awaiting(x=> x.ProcessAsync(messageStateHandler.Object, pipelineInformation.Object, null, CancellationToken.None))
+                .Should()
+                .ThrowAsync<ApplicationException>();
             //assert
             countable.Verify(x=> x.Count(), Times.Once);
             messageStateHandler.Verify(x => x.CompleteAsync(), Times.Never);

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/SagaMiddlewareTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/SagaMiddlewareTests.cs
@@ -102,7 +102,7 @@ namespace KnightBus.Core.Tests.Unit
 
             //act
             middleware.Awaiting(x=> x.ProcessAsync(messageStateHandler.Object, pipelineInformation.Object, null, CancellationToken.None))
-                .Should().Throw<ApplicationException>();
+                .Should().ThrowAsync<ApplicationException>();
             //assert
             countable.Verify(x=> x.Count(), Times.Once);
             messageStateHandler.Verify(x => x.CompleteAsync(), Times.Never);

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/SemaphoreQueueTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/SemaphoreQueueTests.cs
@@ -54,7 +54,7 @@ namespace KnightBus.Core.Tests.Unit
         }
 
         [Test]
-        public void Should_cancel()
+        public async Task Should_cancel()
         {
             //arrange
             var tokenSource = new CancellationTokenSource();
@@ -64,8 +64,10 @@ namespace KnightBus.Core.Tests.Unit
 
             tokenSource.Cancel();
 
-            semaphore.Awaiting(x=>  x.WaitAsync(token))
-                .Should().ThrowAsync<OperationCanceledException>();
+            await semaphore
+                .Awaiting(x=>  x.WaitAsync(token))
+                .Should()
+                .ThrowAsync<OperationCanceledException>();
 
             //assert
             semaphore.CurrentCount.Should().Be(1);

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/SemaphoreQueueTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/SemaphoreQueueTests.cs
@@ -65,7 +65,7 @@ namespace KnightBus.Core.Tests.Unit
             tokenSource.Cancel();
 
             semaphore.Awaiting(x=>  x.WaitAsync(token))
-                .Should().Throw<OperationCanceledException>();
+                .Should().ThrowAsync<OperationCanceledException>();
 
             //assert
             semaphore.CurrentCount.Should().Be(1);

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/ThrottlingMiddlewareTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/ThrottlingMiddlewareTests.cs
@@ -26,7 +26,8 @@ namespace KnightBus.Core.Tests.Unit
             //act 
             await middleware
                 .Awaiting(x => x.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, CancellationToken.None))
-                .Should().ThrowAsync<Exception>();
+                .Should()
+                .ThrowAsync<Exception>();
 
             //assert
             middleware.CurrentCount.Should().Be(1);
@@ -44,8 +45,10 @@ namespace KnightBus.Core.Tests.Unit
 
             var middleware = new ThrottlingMiddleware(1);
             //act 
-            await middleware.Awaiting(x=> x.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, cts.Token))
-                .Should().ThrowAsync<OperationCanceledException>();
+            await middleware
+                .Awaiting(x=> x.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, cts.Token))
+                .Should()
+                .ThrowAsync<OperationCanceledException>();
             
             //assert
             middleware.CurrentCount.Should().Be(1);

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/ThrottlingMiddlewareTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/ThrottlingMiddlewareTests.cs
@@ -12,23 +12,28 @@ namespace KnightBus.Core.Tests.Unit
     public class ThrottlingMiddlewareTests
     {
         [Test]
-        public void Should_release_throttle_on_exception()
+        public async Task Should_release_throttle_on_exception()
         {
             //arrange
             var nextProcessor = new Mock<IMessageProcessor>();
             var messageStateHandler = new Mock<IMessageStateHandler<TestCommand>>();
-            nextProcessor.Setup(x => x.ProcessAsync(messageStateHandler.Object, CancellationToken.None)).Throws<Exception>();
+            nextProcessor
+                .Setup(x => x.ProcessAsync(messageStateHandler.Object, It.IsAny<CancellationToken>()))
+                .Throws<Exception>();
             
             var middleware = new ThrottlingMiddleware(1);
+
             //act 
-            var action = new Func<Task>(() => middleware.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, CancellationToken.None));
-            action.Should().ThrowAsync<Exception>();
+            await middleware
+                .Awaiting(x => x.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, CancellationToken.None))
+                .Should().ThrowAsync<Exception>();
+
             //assert
             middleware.CurrentCount.Should().Be(1);
         }
 
         [Test]
-        public void Should_release_throttle_when_cancellation_token_cancelled()
+        public async Task Should_release_throttle_when_cancellation_token_cancelled()
         {
             //arrange
             var nextProcessor = new Mock<IMessageProcessor>();
@@ -39,7 +44,7 @@ namespace KnightBus.Core.Tests.Unit
 
             var middleware = new ThrottlingMiddleware(1);
             //act 
-            middleware.Awaiting(x=> x.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, cts.Token))
+            await middleware.Awaiting(x=> x.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, cts.Token))
                 .Should().ThrowAsync<OperationCanceledException>();
             
             //assert

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/ThrottlingMiddlewareTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/ThrottlingMiddlewareTests.cs
@@ -22,7 +22,7 @@ namespace KnightBus.Core.Tests.Unit
             var middleware = new ThrottlingMiddleware(1);
             //act 
             var action = new Func<Task>(() => middleware.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, CancellationToken.None));
-            action.Should().Throw<Exception>();
+            action.Should().ThrowAsync<Exception>();
             //assert
             middleware.CurrentCount.Should().Be(1);
         }
@@ -40,7 +40,7 @@ namespace KnightBus.Core.Tests.Unit
             var middleware = new ThrottlingMiddleware(1);
             //act 
             middleware.Awaiting(x=> x.ProcessAsync(messageStateHandler.Object, Mock.Of<IPipelineInformation>(), nextProcessor.Object, cts.Token))
-                .Should().Throw<OperationCanceledException>();
+                .Should().ThrowAsync<OperationCanceledException>();
             
             //assert
             middleware.CurrentCount.Should().Be(1);

--- a/knightbus/tests/KnightBus.DependencyInjection.Tests.Unit/KnightBus.DependencyInjection.Tests.Unit.csproj
+++ b/knightbus/tests/KnightBus.DependencyInjection.Tests.Unit/KnightBus.DependencyInjection.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/knightbus/tests/KnightBus.DependencyInjection.Tests.Unit/KnightBus.DependencyInjection.Tests.Unit.csproj
+++ b/knightbus/tests/KnightBus.DependencyInjection.Tests.Unit/KnightBus.DependencyInjection.Tests.Unit.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/knightbus/tests/KnightBus.Host.Tests.Unit/KnightBus.Host.Tests.Unit.csproj
+++ b/knightbus/tests/KnightBus.Host.Tests.Unit/KnightBus.Host.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/knightbus/tests/KnightBus.Host.Tests.Unit/KnightBus.Host.Tests.Unit.csproj
+++ b/knightbus/tests/KnightBus.Host.Tests.Unit/KnightBus.Host.Tests.Unit.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\knightbus-microsoft-dependencyinjection\src\KnightBus.Microsoft.DependencyInjection\KnightBus.Microsoft.DependencyInjection.csproj" />

--- a/knightbus/tests/KnightBus.Shared.Tests.Integration/KnightBus.Shared.Tests.Integration.csproj
+++ b/knightbus/tests/KnightBus.Shared.Tests.Integration/KnightBus.Shared.Tests.Integration.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <Authors>BookBeat</Authors>
     <Copyright>Copyright © BookBeat 2020</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="nunit" Version="3.13.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\KnightBus.Host\KnightBus.Host.csproj" />

--- a/knightbus/tests/KnightBus.Shared.Tests.Integration/SagaStoreTests.cs
+++ b/knightbus/tests/KnightBus.Shared.Tests.Integration/SagaStoreTests.cs
@@ -33,7 +33,7 @@ namespace KnightBus.Shared.Tests.Integration
             //act
             await SagaStore.Complete(partitionKey, id);
             //assert
-            SagaStore.Awaiting(x => x.GetSaga<SagaData>(partitionKey, id)).Should().Throw<SagaNotFoundException>();
+            SagaStore.Awaiting(x => x.GetSaga<SagaData>(partitionKey, id)).Should().ThrowAsync<SagaNotFoundException>();
         }
 
         [Test]
@@ -43,7 +43,7 @@ namespace KnightBus.Shared.Tests.Integration
             var partitionKey = Guid.NewGuid().ToString("N");
             var id = Guid.NewGuid().ToString("N");
             //act & assert
-            SagaStore.Awaiting(x => x.Complete(partitionKey, id)).Should().Throw<SagaNotFoundException>();
+            SagaStore.Awaiting(x => x.Complete(partitionKey, id)).Should().ThrowAsync<SagaNotFoundException>();
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace KnightBus.Shared.Tests.Integration
             await SagaStore.Create(partitionKey, id, new SagaData { Message = "yo" }, TimeSpan.FromMinutes(1));
             //act & assert
             SagaStore.Awaiting(x => x.Create(partitionKey, id, new SagaData { Message = "yo" }, TimeSpan.FromMinutes(1)))
-                .Should().Throw<SagaAlreadyStartedException>();
+                .Should().ThrowAsync<SagaAlreadyStartedException>();
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace KnightBus.Shared.Tests.Integration
             var partitionKey = Guid.NewGuid().ToString("N");
             var id = Guid.NewGuid().ToString("N");
             //act & assert
-            SagaStore.Awaiting(x => x.GetSaga<SagaData>(partitionKey, id)).Should().Throw<SagaNotFoundException>();
+            SagaStore.Awaiting(x => x.GetSaga<SagaData>(partitionKey, id)).Should().ThrowAsync<SagaNotFoundException>();
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace KnightBus.Shared.Tests.Integration
             await SagaStore.Create(partitionKey, id, new SagaData { Message = "yo" }, TimeSpan.FromMilliseconds(1));
             await Task.Delay(2);
             //act & assert
-            SagaStore.Awaiting(x => x.GetSaga<SagaData>(partitionKey, id)).Should().Throw<SagaNotFoundException>();
+            SagaStore.Awaiting(x => x.GetSaga<SagaData>(partitionKey, id)).Should().ThrowAsync<SagaNotFoundException>();
         }
 
         [Test]
@@ -116,7 +116,7 @@ namespace KnightBus.Shared.Tests.Integration
             var partitionKey = Guid.NewGuid().ToString("N");
             var id = Guid.NewGuid().ToString("N");
             //act & assert
-            SagaStore.Awaiting(x => x.Update(partitionKey, id, new SagaData())).Should().Throw<SagaNotFoundException>();
+            SagaStore.Awaiting(x => x.Update(partitionKey, id, new SagaData())).Should().ThrowAsync<SagaNotFoundException>();
         }
 
         [Test]

--- a/knightbus/tests/KnightBus.Shared.Tests.Integration/SagaStoreTests.cs
+++ b/knightbus/tests/KnightBus.Shared.Tests.Integration/SagaStoreTests.cs
@@ -33,17 +33,23 @@ namespace KnightBus.Shared.Tests.Integration
             //act
             await SagaStore.Complete(partitionKey, id);
             //assert
-            SagaStore.Awaiting(x => x.GetSaga<SagaData>(partitionKey, id)).Should().ThrowAsync<SagaNotFoundException>();
+            await SagaStore
+                .Awaiting(x => x.GetSaga<SagaData>(partitionKey, id))
+                .Should()
+                .ThrowAsync<SagaNotFoundException>();
         }
 
         [Test]
-        public void Complete_should_throw_when_saga_not_found()
+        public async Task Complete_should_throw_when_saga_not_found()
         {
             //arrange
             var partitionKey = Guid.NewGuid().ToString("N");
             var id = Guid.NewGuid().ToString("N");
             //act & assert
-            SagaStore.Awaiting(x => x.Complete(partitionKey, id)).Should().ThrowAsync<SagaNotFoundException>();
+            await SagaStore
+                .Awaiting(x => x.Complete(partitionKey, id))
+                .Should()
+                .ThrowAsync<SagaNotFoundException>();
         }
 
         [Test]
@@ -83,18 +89,23 @@ namespace KnightBus.Shared.Tests.Integration
             var id = Guid.NewGuid().ToString("N");
             await SagaStore.Create(partitionKey, id, new SagaData { Message = "yo" }, TimeSpan.FromMinutes(1));
             //act & assert
-            SagaStore.Awaiting(x => x.Create(partitionKey, id, new SagaData { Message = "yo" }, TimeSpan.FromMinutes(1)))
-                .Should().ThrowAsync<SagaAlreadyStartedException>();
+            await SagaStore
+                .Awaiting(x => x.Create(partitionKey, id, new SagaData { Message = "yo" }, TimeSpan.FromMinutes(1)))
+                .Should()
+                .ThrowAsync<SagaAlreadyStartedException>();
         }
 
         [Test]
-        public void Should_throw_when_get_and_saga_does_not_exist()
+        public async Task Should_throw_when_get_and_saga_does_not_exist()
         {
             //arrange
             var partitionKey = Guid.NewGuid().ToString("N");
             var id = Guid.NewGuid().ToString("N");
             //act & assert
-            SagaStore.Awaiting(x => x.GetSaga<SagaData>(partitionKey, id)).Should().ThrowAsync<SagaNotFoundException>();
+            await SagaStore
+                .Awaiting(x => x.GetSaga<SagaData>(partitionKey, id))
+                .Should()
+                .ThrowAsync<SagaNotFoundException>();
         }
 
         [Test]
@@ -106,17 +117,23 @@ namespace KnightBus.Shared.Tests.Integration
             await SagaStore.Create(partitionKey, id, new SagaData { Message = "yo" }, TimeSpan.FromMilliseconds(1));
             await Task.Delay(2);
             //act & assert
-            SagaStore.Awaiting(x => x.GetSaga<SagaData>(partitionKey, id)).Should().ThrowAsync<SagaNotFoundException>();
+            await SagaStore
+                .Awaiting(x => x.GetSaga<SagaData>(partitionKey, id))
+                .Should()
+                .ThrowAsync<SagaNotFoundException>();
         }
 
         [Test]
-        public void Update_should_throw_when_saga_not_found()
+        public async Task Update_should_throw_when_saga_not_found()
         {
             //arrange
             var partitionKey = Guid.NewGuid().ToString("N");
             var id = Guid.NewGuid().ToString("N");
             //act & assert
-            SagaStore.Awaiting(x => x.Update(partitionKey, id, new SagaData())).Should().ThrowAsync<SagaNotFoundException>();
+            await SagaStore
+                .Awaiting(x => x.Update(partitionKey, id, new SagaData()))
+                .Should()
+                .ThrowAsync<SagaNotFoundException>();
         }
 
         [Test]


### PR DESCRIPTION
Updated targets from net5.0 -> net6.0.
Updated Azure.Messaging.ServiceBus 7.2.0 -> 7.5.1
Updated FluentAssertions 5.10.3 -> 6.2.0
Updated nunit 3.12.0 -> 3.13.2
Updated NUnit3TestAdapter 3.17.0 -> 4.1.0
Updated Microsoft.NET.Test.Sdk 16.7.0 -> 17.0.0
Updated Microsoft.Extensions.Hosting 5.0.0 -> 6.0.0
Updated Microsoft.Extensions.DependencyInjection 5.0.0 -> 6.0.0
Updated System.Text.Json 5.0.0 -> 6.0.1
Updated System.Data.SqlClient 4.8.2 -> 4.8.3
Updated SimpleInjector 5.3.0 -> 5.3.2
Updated System.Linq.Async 4.1.1 -> 5.1.0
Updated Microsoft.Bcl.AsyncInterfaces 5.0.0 -> 6.0.0
Updated StackExchange.Redis 2.2.79 -> 2.2.88
Updated NewRelic.Agent.Api 8.39.1 -> 9.2.0
Updated MessagePack 2.2.85 -> 2.3.85
Updated Microsoft.ApplicationInsights.DependencyCollector 2.17.0 -> 2.20.0
Updated Microsoft.ApplicationInsights.PerfCounterCollector 2.17.0 -> 2.20.0