### PR TITLE
Implement support for restart in case max idle time is reached

### DIFF
--- a/documentation/source/credits.rst
+++ b/documentation/source/credits.rst
@@ -19,3 +19,4 @@ Unordered list of persons contributing their time and intellect to KnightBus
 * Simon Aunér
 * André Virdarson
 * Tobias Balzano
+* Peter Bergman

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/CHANGELOG.md
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# KnightBus.Azure.ServiceBus Changelog
 
+## 15.1.0
+### Added
+- Possibility to automatically force restart of Azure ServiceBus receivers after a fixed idle period (i.e. no messages processed). Specified through `IRestartTransportOnIdle`.
+
 ## 9.0.0
 
 - `ServiceBusCreationOptions` implements `IServiceBusCreationOptions`.

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/IRestartTransportOnIdle.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/IRestartTransportOnIdle.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace KnightBus.Azure.ServiceBus
+{
+    /// <summary>
+    /// Will restart the receiver of the transport if idle (i.e. no messages processed) for TimeSpan
+    /// </summary>
+    public interface IRestartTransportOnIdle
+    {
+        public TimeSpan IdleTimeout { get; }
+    }
+}

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>15.0.0</Version>
+    <Version>15.1.0</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusChannelReceiverBase.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusChannelReceiverBase.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using KnightBus.Core;
+using KnightBus.Messages;
+
+namespace KnightBus.Azure.ServiceBus
+{
+    internal abstract class ServiceBusChannelReceiverBase<T> : IChannelReceiver
+        where T : class, IMessage
+    {
+        protected IClientFactory ClientFactory;
+        public IProcessingSettings Settings { get; set; }
+        protected readonly ILog Log;
+        protected readonly IMessageSerializer Serializer;
+        protected readonly IServiceBusConfiguration Configuration;
+        protected readonly IHostConfiguration HostConfiguration;
+        protected readonly IMessageProcessor Processor;
+        protected int DeadLetterLimit;
+        protected ServiceBusProcessor Client;
+        protected ServiceBusAdministrationClient ManagementClient;
+        protected CancellationToken CancellationToken;
+        protected CancellationTokenSource RestartTaskCancellation;
+        protected DateTimeOffset LastProcess;
+        protected readonly object Locker = new object();
+
+        protected ServiceBusChannelReceiverBase(IProcessingSettings settings, IMessageSerializer serializer, IServiceBusConfiguration configuration, IHostConfiguration hostConfiguration, IMessageProcessor processor)
+        {
+            Serializer = serializer;
+            Configuration = configuration;
+            HostConfiguration = hostConfiguration;
+            Processor = processor;
+            Settings = settings;
+            Log = hostConfiguration.Log;
+            //new client factory per ServiceBusQueueChannelReceiver means a separate communication channel per reader instead of a shared
+            ClientFactory = new ClientFactory(configuration.ConnectionString);
+            ManagementClient = new ServiceBusAdministrationClient(configuration.ConnectionString);
+            LastProcess = DateTimeOffset.UtcNow;
+        }
+
+        public abstract Task StartAsync(CancellationToken cancellationToken);
+
+        protected async Task CheckIdleTime(TimeSpan idleTimeout)
+        {
+            lock (Locker)
+            {
+                var timeSinceLastProcessedMessage = DateTimeOffset.UtcNow - LastProcess;
+
+                if (timeSinceLastProcessedMessage < idleTimeout) return;
+
+                Log.Information($"Last message was processed at: {LastProcess} (maximum allowed idle timespan: {idleTimeout}), restarting");
+            }
+
+            await RestartAsync().ConfigureAwait(false);
+        }
+
+        protected async Task RestartAsync()
+        {
+            try
+            {
+                Log.Information($"Restarting {typeof(T).Name}");
+
+                await Client.StopProcessingAsync(CancellationToken).ConfigureAwait(false);
+                Client.ProcessMessageAsync -= ClientOnProcessMessageAsync;
+                Client.ProcessErrorAsync -= ClientOnProcessErrorAsync;
+
+                RestartTaskCancellation.Cancel();
+
+                await ClientFactory.DisposeAsync().ConfigureAwait(false);
+
+                ClientFactory = new ClientFactory(Configuration.ConnectionString);
+                ManagementClient = new ServiceBusAdministrationClient(Configuration.ConnectionString);
+
+                await StartAsync(CancellationToken).ConfigureAwait(false);
+                Log.Information($"Successfully restarted {typeof(T).Name}");
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, $"Failed to restart {typeof(T).Name}");
+                await RestartAsync().ConfigureAwait(false);
+            }
+        }
+
+        protected Task ClientOnProcessErrorAsync(ProcessErrorEventArgs arg)
+        {
+            if (!(arg.Exception is OperationCanceledException))
+            {
+                Log.Error(arg.Exception, $"{typeof(T).Name}");
+            }
+            return Task.CompletedTask;
+        }
+
+        protected async Task ClientOnProcessMessageAsync(ProcessMessageEventArgs arg)
+        {
+            try
+            {
+                var stateHandler = new ServiceBusMessageStateHandler<T>(arg, Serializer, DeadLetterLimit, HostConfiguration.DependencyInjection);
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, arg.CancellationToken);
+                await Processor.ProcessAsync(stateHandler, cts.Token).ConfigureAwait(false);
+                lock (Locker)
+                {
+                    LastProcess = DateTimeOffset.UtcNow;
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "ServiceBus OnMessage Failed");
+            }
+        }
+
+        protected IServiceBusCreationOptions GetServiceBusCreationOptions()
+        {
+            var queueMapping = AutoMessageMapper.GetMapping<T>();
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            var creationOptions = queueMapping as IServiceBusCreationOptions;
+
+            return creationOptions ?? Configuration.DefaultCreationOptions;
+        }
+    }
+}

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusQueueChannelReceiver.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusQueueChannelReceiver.cs
@@ -80,17 +80,15 @@ namespace KnightBus.Azure.ServiceBus
 
 
             RestartTaskCancellation = new CancellationTokenSource();
-            var linked = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, RestartTaskCancellation.Token);
-
             // ReSharper disable once SuspiciousTypeConversion.Global
             if (Settings is IRestartTransportOnIdle restartOnIdle)
             {
-                Log.Information($"Starting idle timeout check for {typeof(T).Name}");
+                Log.Information($"Starting idle timeout check for {typeof(T).Name} with maximum allowed idle timespan: {restartOnIdle.IdleTimeout}");
                 Task.Run(async () =>
                 {
                     while (!RestartTaskCancellation.IsCancellationRequested)
                     {
-                        await Task.Delay(TimeSpan.FromSeconds(10), linked.Token).ConfigureAwait(false);
+                        await Task.Delay(TimeSpan.FromSeconds(10), RestartTaskCancellation.Token).ConfigureAwait(false);
                         await CheckIdleTime(restartOnIdle.IdleTimeout).ConfigureAwait(false);
                     }
                 }, RestartTaskCancellation.Token);

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusTopicChannelReceiver.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusTopicChannelReceiver.cs
@@ -100,8 +100,6 @@ namespace KnightBus.Azure.ServiceBus
             });
 
             RestartTaskCancellation = new CancellationTokenSource();
-            var linked = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, RestartTaskCancellation.Token);
-
             // ReSharper disable once SuspiciousTypeConversion.Global
             if (Settings is IRestartTransportOnIdle restartOnIdle)
             {
@@ -110,7 +108,7 @@ namespace KnightBus.Azure.ServiceBus
                 {
                     while (!RestartTaskCancellation.IsCancellationRequested)
                     {
-                        await Task.Delay(TimeSpan.FromSeconds(10), linked.Token).ConfigureAwait(false);
+                        await Task.Delay(TimeSpan.FromSeconds(10), RestartTaskCancellation.Token).ConfigureAwait(false);
                         await CheckIdleTime(restartOnIdle.IdleTimeout).ConfigureAwait(false);
                     }
                 }, RestartTaskCancellation.Token);

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusTopicChannelReceiver.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusTopicChannelReceiver.cs
@@ -21,10 +21,9 @@ namespace KnightBus.Azure.ServiceBus
             _subscription = subscription;
         }
 
-        public override async Task StartAsync(CancellationToken cancellationToken)
+        protected override Task<ServiceBusProcessor> CreateClient(CancellationToken cancellationToken)
         {
-            CancellationToken = cancellationToken;
-            Client = await ClientFactory.GetReceiverClient<T, IEventSubscription<T>>(_subscription, new ServiceBusProcessorOptions
+            return ClientFactory.GetReceiverClient<T, IEventSubscription<T>>(_subscription, new ServiceBusProcessorOptions
             {
                 AutoCompleteMessages = false,
                 MaxAutoLockRenewalDuration = Settings.MessageLockTimeout,
@@ -32,88 +31,49 @@ namespace KnightBus.Azure.ServiceBus
                 PrefetchCount = Settings.PrefetchCount,
                 ReceiveMode = ServiceBusReceiveMode.PeekLock
 
-            }).ConfigureAwait(false);
-
-
-            var topicName = AutoMessageMapper.GetQueueName<T>();
-
-            if (!await ManagementClient.TopicExistsAsync(topicName, cancellationToken).ConfigureAwait(false))
-            {
-                try
-                {
-                    var serviceBusCreationOptions = GetServiceBusCreationOptions();
-
-                    await ManagementClient.CreateTopicAsync(new CreateTopicOptions(topicName)
-                    {
-                        EnablePartitioning = serviceBusCreationOptions.EnablePartitioning,
-                        EnableBatchedOperations = serviceBusCreationOptions.EnableBatchedOperations,
-                        SupportOrdering = serviceBusCreationOptions.SupportOrdering
-
-                    }, cancellationToken).ConfigureAwait(false);
-                }
-                catch (ServiceBusException e)
-                {
-                    Log.Error(e, "Failed to create topic {TopicName}", topicName);
-                    throw;
-                }
-            }
-            if (!await ManagementClient.SubscriptionExistsAsync(topicName, _subscription.Name, cancellationToken).ConfigureAwait(false))
-            {
-                try
-                {
-                    var serviceBusCreationOptions = GetServiceBusCreationOptions();
-
-                    await ManagementClient.CreateSubscriptionAsync(new CreateSubscriptionOptions(topicName, _subscription.Name)
-                    {
-                        EnableBatchedOperations = serviceBusCreationOptions.EnableBatchedOperations
-                    }, cancellationToken).ConfigureAwait(false);
-                }
-                catch (ServiceBusException e)
-                {
-                    Log.Error(e, "Failed to create subscription {TopicName} {SubscriptionName}", topicName, _subscription.Name);
-                    throw;
-                }
-            }
-
-            DeadLetterLimit = Settings.DeadLetterDeliveryLimit;
-
-            Client.ProcessMessageAsync += ClientOnProcessMessageAsync;
-            Client.ProcessErrorAsync += ClientOnProcessErrorAsync;
-
-            await Client.StartProcessingAsync(cancellationToken);
-
-#pragma warning disable 4014
-            // ReSharper disable once MethodSupportsCancellation
-            Task.Run(async () =>
-            {
-                CancellationToken.WaitHandle.WaitOne();
-                //Cancellation requested
-                try
-                {
-                    Log.Information($"Closing ServiceBus channel receiver for {typeof(T).Name}");
-                    await Client.CloseAsync(CancellationToken.None);
-                }
-                catch (Exception)
-                {
-                    //Swallow
-                }
             });
+        }
 
-            RestartTaskCancellation = new CancellationTokenSource();
-            // ReSharper disable once SuspiciousTypeConversion.Global
-            if (Settings is IRestartTransportOnIdle restartOnIdle)
+        protected override async Task CreateMessagingEntity(CancellationToken cancellationToken)
+        {
+            var topicName = AutoMessageMapper.GetQueueName<T>();
+            var serviceBusCreationOptions = GetServiceBusCreationOptions();
+            try
             {
-                Log.Information($"Starting idle timeout check for {typeof(T).Name} with maximum allowed idle timespan: {restartOnIdle.IdleTimeout}");
-                Task.Run(async () =>
+                await ManagementClient.CreateTopicAsync(new CreateTopicOptions(topicName)
                 {
-                    while (!RestartTaskCancellation.IsCancellationRequested)
-                    {
-                        await Task.Delay(TimeSpan.FromSeconds(10), RestartTaskCancellation.Token).ConfigureAwait(false);
-                        await CheckIdleTime(restartOnIdle.IdleTimeout).ConfigureAwait(false);
-                    }
-                }, RestartTaskCancellation.Token);
+                    EnablePartitioning = serviceBusCreationOptions.EnablePartitioning,
+                    EnableBatchedOperations = serviceBusCreationOptions.EnableBatchedOperations,
+                    SupportOrdering = serviceBusCreationOptions.SupportOrdering
+
+                }, cancellationToken).ConfigureAwait(false);
             }
-#pragma warning restore 4014
+            catch (ServiceBusException e) when (e.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
+            {
+                //Swallow
+            }
+            catch (ServiceBusException e)
+            {
+                Log.Error(e, "Failed to create topic {TopicName}", topicName);
+                throw;
+            }
+
+            try
+            {
+                await ManagementClient.CreateSubscriptionAsync(new CreateSubscriptionOptions(topicName, _subscription.Name)
+                {
+                    EnableBatchedOperations = serviceBusCreationOptions.EnableBatchedOperations
+                }, cancellationToken).ConfigureAwait(false);
+            }
+            catch (ServiceBusException e) when (e.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
+            {
+                //Swallow
+            }
+            catch (ServiceBusException e)
+            {
+                Log.Error(e, "Failed to create subscription {TopicName} {SubscriptionName}", topicName, _subscription.Name);
+                throw;
+            }
         }
     }
 }

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusTopicChannelReceiver.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/ServiceBusTopicChannelReceiver.cs
@@ -8,59 +8,42 @@ using KnightBus.Messages;
 
 namespace KnightBus.Azure.ServiceBus
 {
-    internal class ServiceBusTopicChannelReceiver<TTopic> : IChannelReceiver
-        where TTopic : class, IEvent
+    internal class ServiceBusTopicChannelReceiver<T> : ServiceBusChannelReceiverBase<T>, IChannelReceiver
+        where T : class, IEvent
     {
-        private readonly IClientFactory _clientFactory;
-        public IProcessingSettings Settings { get; set; }
-        private readonly ServiceBusAdministrationClient _managementClient;
-        private readonly IMessageSerializer _serializer;
-        private readonly IEventSubscription<TTopic> _subscription;
-        private readonly ILog _log;
-        private readonly IServiceBusConfiguration _configuration;
-        private readonly IHostConfiguration _hostConfiguration;
-        private readonly IMessageProcessor _processor;
-        private int _deadLetterLimit;
-        private ServiceBusProcessor _client;
-        private CancellationToken _cancellationToken;
+        private readonly IEventSubscription<T> _subscription;
 
-        public ServiceBusTopicChannelReceiver(IProcessingSettings settings, IMessageSerializer serializer, IEventSubscription<TTopic> subscription, IServiceBusConfiguration configuration, IHostConfiguration hostConfiguration, IMessageProcessor processor)
+        public ServiceBusTopicChannelReceiver(IProcessingSettings settings, IMessageSerializer serializer,
+            IEventSubscription<T> subscription, IServiceBusConfiguration configuration,
+            IHostConfiguration hostConfiguration, IMessageProcessor processor) : base(settings, serializer,
+            configuration, hostConfiguration, processor)
         {
-            Settings = settings;
-            _managementClient = new ServiceBusAdministrationClient(configuration.ConnectionString);
-            _serializer = serializer;
             _subscription = subscription;
-            _log = hostConfiguration.Log;
-            _configuration = configuration;
-            _hostConfiguration = hostConfiguration;
-            _processor = processor;
-            //new client factory per ServiceBusTopicChannelReceiver means a separate communication channel per reader instead of a shared
-            _clientFactory = new ClientFactory(configuration.ConnectionString);
         }
 
-        public async Task StartAsync(CancellationToken cancellationToken)
+        public override async Task StartAsync(CancellationToken cancellationToken)
         {
-            _cancellationToken = cancellationToken;
-            _client = await _clientFactory.GetReceiverClient<TTopic, IEventSubscription<TTopic>>(_subscription, new ServiceBusProcessorOptions
+            CancellationToken = cancellationToken;
+            Client = await ClientFactory.GetReceiverClient<T, IEventSubscription<T>>(_subscription, new ServiceBusProcessorOptions
             {
                 AutoCompleteMessages = false,
                 MaxAutoLockRenewalDuration = Settings.MessageLockTimeout,
                 MaxConcurrentCalls = Settings.MaxConcurrentCalls,
                 PrefetchCount = Settings.PrefetchCount,
                 ReceiveMode = ServiceBusReceiveMode.PeekLock
-                
+
             }).ConfigureAwait(false);
 
-            
-            var topicName = AutoMessageMapper.GetQueueName<TTopic>();
-            
-            if (!await _managementClient.TopicExistsAsync(topicName, cancellationToken).ConfigureAwait(false))
+
+            var topicName = AutoMessageMapper.GetQueueName<T>();
+
+            if (!await ManagementClient.TopicExistsAsync(topicName, cancellationToken).ConfigureAwait(false))
             {
                 try
                 {
                     var serviceBusCreationOptions = GetServiceBusCreationOptions();
 
-                    await _managementClient.CreateTopicAsync(new CreateTopicOptions(topicName)
+                    await ManagementClient.CreateTopicAsync(new CreateTopicOptions(topicName)
                     {
                         EnablePartitioning = serviceBusCreationOptions.EnablePartitioning,
                         EnableBatchedOperations = serviceBusCreationOptions.EnableBatchedOperations,
@@ -70,83 +53,69 @@ namespace KnightBus.Azure.ServiceBus
                 }
                 catch (ServiceBusException e)
                 {
-                    _log.Error(e, "Failed to create topic {TopicName}", topicName);
+                    Log.Error(e, "Failed to create topic {TopicName}", topicName);
                     throw;
                 }
             }
-            if (!await _managementClient.SubscriptionExistsAsync(topicName, _subscription.Name, cancellationToken).ConfigureAwait(false))
+            if (!await ManagementClient.SubscriptionExistsAsync(topicName, _subscription.Name, cancellationToken).ConfigureAwait(false))
             {
                 try
                 {
                     var serviceBusCreationOptions = GetServiceBusCreationOptions();
 
-                    await _managementClient.CreateSubscriptionAsync(new CreateSubscriptionOptions(topicName, _subscription.Name)
+                    await ManagementClient.CreateSubscriptionAsync(new CreateSubscriptionOptions(topicName, _subscription.Name)
                     {
                         EnableBatchedOperations = serviceBusCreationOptions.EnableBatchedOperations
                     }, cancellationToken).ConfigureAwait(false);
                 }
                 catch (ServiceBusException e)
                 {
-                    _log.Error(e, "Failed to create subscription {TopicName} {SubscriptionName}", topicName, _subscription.Name);
+                    Log.Error(e, "Failed to create subscription {TopicName} {SubscriptionName}", topicName, _subscription.Name);
                     throw;
                 }
             }
 
-            _deadLetterLimit = Settings.DeadLetterDeliveryLimit;
-            
-            _client.ProcessMessageAsync += ClientOnProcessMessageAsync;
-            _client.ProcessErrorAsync += ClientOnProcessErrorAsync;
+            DeadLetterLimit = Settings.DeadLetterDeliveryLimit;
 
-            await _client.StartProcessingAsync(cancellationToken);
-            
+            Client.ProcessMessageAsync += ClientOnProcessMessageAsync;
+            Client.ProcessErrorAsync += ClientOnProcessErrorAsync;
+
+            await Client.StartProcessingAsync(cancellationToken);
+
 #pragma warning disable 4014
             // ReSharper disable once MethodSupportsCancellation
             Task.Run(async () =>
             {
-                _cancellationToken.WaitHandle.WaitOne();
+                CancellationToken.WaitHandle.WaitOne();
                 //Cancellation requested
                 try
                 {
-                    _log.Information($"Closing ServiceBus channel receiver for {typeof(TTopic).Name}");
-                     await _client.CloseAsync(CancellationToken.None);
+                    Log.Information($"Closing ServiceBus channel receiver for {typeof(T).Name}");
+                    await Client.CloseAsync(CancellationToken.None);
                 }
                 catch (Exception)
                 {
                     //Swallow
                 }
             });
+
+            RestartTaskCancellation = new CancellationTokenSource();
+            var linked = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, RestartTaskCancellation.Token);
+
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            if (Settings is IRestartTransportOnIdle restartOnIdle)
+            {
+                Log.Information($"Starting idle timeout check for {typeof(T).Name} with maximum allowed idle timespan: {restartOnIdle.IdleTimeout}");
+                Task.Run(async () =>
+                {
+                    while (!RestartTaskCancellation.IsCancellationRequested)
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(10), linked.Token).ConfigureAwait(false);
+                        await CheckIdleTime(restartOnIdle.IdleTimeout).ConfigureAwait(false);
+                    }
+                }, RestartTaskCancellation.Token);
+            }
 #pragma warning restore 4014
-        }
-
-        private Task ClientOnProcessErrorAsync(ProcessErrorEventArgs arg)
-        {
-            if (!(arg.Exception is OperationCanceledException))
-            {
-                _log.Error(arg.Exception, $"{typeof(ServiceBusTopicChannelReceiver<TTopic>).Name}");
-            }
-            return Task.CompletedTask;
-        }
-
-        private async Task ClientOnProcessMessageAsync(ProcessMessageEventArgs arg)
-        {
-            try
-            {
-                var stateHandler = new ServiceBusMessageStateHandler<TTopic>(arg, _serializer, _deadLetterLimit, _hostConfiguration.DependencyInjection);
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken, arg.CancellationToken);
-                await _processor.ProcessAsync(stateHandler, cts.Token).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                _log.Error(e, "ServiceBus OnMessage Failed");
-            }
-        }
-
-        private IServiceBusCreationOptions GetServiceBusCreationOptions()
-        {
-            var queueMapping = AutoMessageMapper.GetMapping<TTopic>();
-            var creationOptions = queueMapping as IServiceBusCreationOptions;
-
-            return creationOptions ?? _configuration.DefaultCreationOptions;
         }
     }
 }


### PR DESCRIPTION
We have sometimes seen that specific Azure Service Bus receivers stop processing messages. The theory is that the underlaying connection to Azure Service Bus held by the client is somehow interrupted without the application knowing of it. When this occurs, the issue can be resolved by forcing a restart of the faulty receiver. 

This PR adds support to opt-in for automatic restart of a receiver after a maximum idle period (i.e. no messages processed). The functionality is implemented for both queue and topic receivers so I therefore introduced a new base class to hold some common code for both types.  

Bonus: both queue and topic receivers has been modified to use an optimistic approach at startup for handling creation o queue/topic/subscription.