### PR TITLE
Optimistic startup of StorageQueueChannelReceiver

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ before_test:
 - docker pull redis
 - docker run -d -p 6379:6379 --name redis6379 redis
 - docker run -d -p 4222:4222 nats:latest
-- docker run -d -p 10000:10000 mcr.microsoft.com/azure-storage/azurite
+- docker run -d -p 10000:10000 -p 10001:10001 mcr.microsoft.com/azure-storage/azurite
 
 test_script:
 - cmd: >-

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage/KnightBus.Azure.Storage.csproj
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage/KnightBus.Azure.Storage.csproj
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>12.0.0</Version>
+    <Version>12.1.0</Version>
     <PackageTags>knightbus;azure storage;blob;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage/StorageQueueChannelReceiver.cs
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage/StorageQueueChannelReceiver.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage/StorageQueueChannelReceiver.cs
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage/StorageQueueChannelReceiver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,15 +38,14 @@ namespace KnightBus.Azure.Storage
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            await Initialize().ConfigureAwait(false);
+            Initialize();
             await _messagePump.StartAsync<T>(Handle, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task Initialize()
+        private void Initialize()
         {
             var queueName = AutoMessageMapper.GetQueueName<T>();
             _storageQueueClient = new StorageQueueClient(_storageOptions, _serializer, null, queueName);
-            await _storageQueueClient.CreateIfNotExistsAsync().ConfigureAwait(false);
             _messagePump = new StorageQueueMessagePump(_storageQueueClient, Settings, _hostConfiguration.Log);
         }
 

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage/StorageQueueMessagePump.cs
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage/StorageQueueMessagePump.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
@@ -104,7 +105,7 @@ namespace KnightBus.Azure.Storage
 #pragma warning restore 4014
                 }
             }
-            catch (RequestFailedException e) when (e.ErrorCode is "QueueNotFound")
+            catch (RequestFailedException e) when (e.Status is (int)HttpStatusCode.NotFound)
             {
                 _log.Information($"{typeof(T).Name} not found. Creating.");
                 await _storageQueueClient.CreateIfNotExistsAsync().ConfigureAwait(false);

--- a/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/StorageQueueMessagePumpTests.cs
+++ b/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/StorageQueueMessagePumpTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using KnightBus.Azure.Storage.Messages;
+using KnightBus.Core;
+using KnightBus.Messages;
+using KnightBus.Newtonsoft;
+using Moq;
+using NUnit.Framework;
+
+namespace KnightBus.Azure.Storage.Tests.Integration
+{
+    public class StorageQueueMessagePumpTests
+    {
+        private StorageQueueClient _storageQueueClient;
+        private StorageQueueMessagePump _pump;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _storageQueueClient = new StorageQueueClient(
+                new StorageBusConfiguration("UseDevelopmentStorage=true"),
+                new NewtonsoftSerializer(),
+                new BlobStorageMessageAttachmentProvider("UseDevelopmentStorage=true"),
+                $"{GetType().Name}-{DateTime.UtcNow.Ticks}".ToLower());
+            var settings = new TestMessageSettings();
+            var log = new Mock<ILog>();
+            _pump = new StorageQueueMessagePump(_storageQueueClient, settings, log.Object);
+        }
+
+        [Test]
+        public async Task PumpAsync_WhenQueuesDoesNotExist_ShouldCreateQueuesWithoutThrowing()
+        {
+            // Arrange
+            // Act
+            await _pump.PumpAsync<TestCommand>((_, _) => Task.CompletedTask, CancellationToken.None);
+
+            // Assert - should not throw
+            await _storageQueueClient.GetQueueCountAsync();
+            await _storageQueueClient.GetDeadLetterCountAsync();
+        }
+
+        [TearDown]
+        public async Task TearDown()
+        {
+            await _storageQueueClient.DeleteIfExistsAsync();
+        }
+    }
+
+    public class TestMessageSettings : IProcessingSettings
+    {
+        public int MaxConcurrentCalls { get; set; } = 1;
+        public TimeSpan MessageLockTimeout { get; set; } = TimeSpan.FromMinutes(1);
+        public int DeadLetterDeliveryLimit { get; set; } = 1;
+        public int PrefetchCount { get; set; }
+    }
+
+    public class TestCommandMessageMapping : IMessageMapping<TestCommand>
+    {
+        public string QueueName => "longrunningtestcommand";
+    }
+
+    public class TestCommand : IStorageQueueCommand
+    {
+        public string Message { get; set; }
+    }
+}


### PR DESCRIPTION
Instead of doing a call to `CreateIfNotExistsAsync` in the startup of the receiver, we now assume that all resources exists at startup and act on `RequestFailedException` in the pump. 