### PR TITLE
Simplify Azure ServiceBus receiver restart mechanism

### DIFF
--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/CHANGELOG.md
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# KnightBus.Azure.ServiceBus Changelog
 
+## 15.1.2
+### Changed 
+- Simplify restart handling when using `IRestartTransportOnIdle`.
+
 ## 15.1.1
 ### Fixed
 - Prevent potential memory leak when using `IRestartTransportOnIdle`.

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>15.1.1</Version>
+    <Version>15.1.2</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
In this PR, I have refactored so that we have a separate method for initializing resources (`InitializeAsync`) so that we don't have to call `StartAsync` when restarting. This removes the need for multiple cancellation tokens, instead we can let both tasks created in `StartAsync` run until the main cancellation token has been cancelled. I think this makes it a bit easier to reason about what's going on in the startup code.