### PR TITLE
Log the fullname of the channel receivers

### DIFF
--- a/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
+++ b/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>14.0.3</Version>
+    <Version>14.0.4</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/knightbus/src/KnightBus.Host/KnightBusHost.cs
+++ b/knightbus/src/KnightBus.Host/KnightBusHost.cs
@@ -48,7 +48,7 @@ namespace KnightBus.Host
                 _configuration.Log.LogInformation("Starting receivers");
                 foreach (var receiver in channelReceivers)
                 {
-                    _configuration.Log.LogInformation("Starting receiver {ReceiverType}", receiver.GetType().Name);
+                    _configuration.Log.LogInformation("Starting receiver {ReceiverType}", receiver.GetType());
                     await receiver.StartAsync(combinedToken.Token).ConfigureAwait(false);
                 }
 


### PR DESCRIPTION
Log the full name of the channel receivers instead of only getting the generic name but without getting the Version etc. 
 
For example:

```
new List<string>().GetType().Name: List`1
new List<string>().GetType().FullName: System.Collections.Generic.List`1[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
new List<string>().GetType(): System.Collections.Generic.List`1[System.String]

```
