### PR TITLE
fix: allow inserting more than 65535 messages

### DIFF
--- a/knightbus-postgresql/src/KnightBus.PostgreSql/KnightBus.PostgreSql.csproj
+++ b/knightbus-postgresql/src/KnightBus.PostgreSql/KnightBus.PostgreSql.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/knightbus-postgresql/tests/KnightBus.PostgreSql.Tests.Integration/PostgresBusTests.cs
+++ b/knightbus-postgresql/tests/KnightBus.PostgreSql.Tests.Integration/PostgresBusTests.cs
@@ -86,6 +86,25 @@ public class PostgresBusTests
     }
 
     [Test]
+    public async Task InsertALotOfMessages()
+    {
+        TestCommand[] messages = new TestCommand[100000];
+        Array.Fill(messages, new TestCommand { MessageBody = "Hej" }, 0, 100000);
+
+        await _postgresBus.SendAsync<TestCommand>(messages, CancellationToken.None);
+
+        var messagesCount = (long)(
+            await PostgresSetup
+                .DataSource.CreateCommand(
+                    $"SELECT COUNT(*) FROM knightbus.q_{AutoMessageMapper.GetQueueName<TestCommand>()};"
+                )
+                .ExecuteScalarAsync() ?? 0
+        );
+
+        messagesCount.Should().Be(100_000);
+    }
+
+    [Test]
     public async Task GetMessages()
     {
         await _postgresBus.SendAsync<TestCommand>(

--- a/knightbus-postgresql/tests/KnightBus.PostgreSql.Tests.Integration/PostgresMessageStateHandlerTests.cs
+++ b/knightbus-postgresql/tests/KnightBus.PostgreSql.Tests.Integration/PostgresMessageStateHandlerTests.cs
@@ -26,13 +26,13 @@ public class PostgresMessageStateHandlerTests : MessageStateHandlerTests<Postgre
             new PostgresConfiguration { MessageSerializer = new MicrosoftJsonSerializer() }
         );
 
-        await _postgresManagementClient.DeleteQueue(
+        await QueueInitializer.InitQueue(
             PostgresQueueName.Create(AutoMessageMapper.GetQueueName<PostgresTestCommand>()),
-            default
+            PostgresSetup.DataSource
         );
     }
 
-    [OneTimeTearDown]
+    [TearDown]
     public async Task CleanUpAfterTests()
     {
         await _postgresManagementClient.DeleteQueue(


### PR DESCRIPTION
Vi failar insert om vi försöker sätta in mer än 65535 meddelanden.

- Fixa så man kan skicka mer än 65535 meddelanden i en batch
- Kör batch insert om färre än 50 meddelanden. Annars kör vi COPY vilket bör öka performance med 50-70% enligt mina benchmarks 🤞🏻 (100k meddelanden i en insert). Overheaden för copy är större än nyttan vi får om vi kör copy med få antal meddelanden

re-take på https://github.com/BookBeat/knightbus/pull/133