### PR TITLE
Chore: Bump ServiceBus

### DIFF
--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -11,12 +11,12 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>22.0.0</Version>
+    <Version>22.1.0</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.4" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="knighbus-64.png" Pack="true" Visible="false" PackagePath="" />


### PR DESCRIPTION
## What
Bump Azure.Messaging.ServiceBus

## Why
Azure.Messaging.ServiceBus 7.18.4 contains a bug where Service Bus Processor get stuck when not completing or abandoning messages with prefetch count > 0

https://github.com/Azure/azure-sdk-for-net/issues/49018