### PR TITLE
fix(blob-storage): fallback to default lock scheme if missing

### DIFF
--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage.Management/KnightBus.Azure.Storage.Management.csproj
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage.Management/KnightBus.Azure.Storage.Management.csproj
@@ -9,7 +9,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>2.5.0</Version>
+    <Version>2.5.1</Version>
     <PackageTags>knightbus;azure storage;blob;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage/KnightBus.Azure.Storage.csproj
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage/KnightBus.Azure.Storage.csproj
@@ -9,7 +9,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>17.4.0</Version>
+    <Version>17.4.1</Version>
     <PackageTags>knightbus;azure storage;blob;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage/Singleton/BlobLockManager.cs
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage/Singleton/BlobLockManager.cs
@@ -19,10 +19,7 @@ internal class BlobLockManager : ISingletonLockManager
     private readonly IBlobLockScheme _lockScheme;
 
     public BlobLockManager(string connectionString, IBlobLockScheme lockScheme = null)
-        : this(
-            new StorageBusConfiguration(connectionString),
-            lockScheme ?? new DefaultBlobLockScheme()
-        ) { }
+        : this(new StorageBusConfiguration(connectionString), lockScheme) { }
 
     public BlobLockManager(
         IStorageBusConfiguration configuration,
@@ -30,7 +27,7 @@ internal class BlobLockManager : ISingletonLockManager
     )
     {
         _configuration = configuration;
-        _lockScheme = lockScheme;
+        _lockScheme = lockScheme ?? new DefaultBlobLockScheme();
     }
 
     public Task InitializeAsync()


### PR DESCRIPTION
### What
* Fallback to `DefaultBlobLockScheme` if not specified

### Why
Not doing this caused `System.NullReferenceException` in `InitializeAsync`