### PR TITLE
fix(knightbus): breakout IQueueMessageAttachmentProvider

### DIFF
--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus.Management/KnightBus.Azure.ServiceBus.Management.csproj
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus.Management/KnightBus.Azure.ServiceBus.Management.csproj
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>4.0.0$(VersionSuffix)</Version>
+    <Version>4.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus.Management/ServiceBusExtensions.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus.Management/ServiceBusExtensions.cs
@@ -10,7 +10,8 @@ public static class ServiceBusExtensions
 {
     internal static QueueProperties ToQueueProperties(
         this QueueRuntimeProperties properties,
-        IQueueManager manager
+        IQueueManager manager,
+        long? maxSizeInMegabytes = null
     )
     {
         return new QueueProperties(properties.Name, manager, true)
@@ -18,6 +19,7 @@ public static class ServiceBusExtensions
             ActiveMessageCount = properties.ActiveMessageCount,
             TotalMessageCount = properties.TotalMessageCount,
             SizeInBytes = properties.SizeInBytes,
+            MaxSizeInMegabytes = maxSizeInMegabytes,
             TransferMessageCount = properties.TransferMessageCount,
             DeadLetterMessageCount = properties.DeadLetterMessageCount,
             TransferDeadLetterMessageCount = properties.TransferDeadLetterMessageCount,

--- a/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus.Management/ServiceBusQueueManager.cs
+++ b/knightbus-azureservicebus/src/KnightBus.Azure.ServiceBus.Management/ServiceBusQueueManager.cs
@@ -35,10 +35,13 @@ public class ServiceBusQueueManager : IQueueManager, IQueueMessageSender, IAsync
 
     public async Task<QueueProperties> Get(string path, CancellationToken ct)
     {
-        var props = await _adminClient
-            .GetQueueRuntimePropertiesAsync(path, ct)
-            .ConfigureAwait(false);
-        return props.Value.ToQueueProperties(this);
+        var runtimePropsTask = _adminClient.GetQueueRuntimePropertiesAsync(path, ct);
+        var queuePropsTask = _adminClient.GetQueueAsync(path, ct);
+        await Task.WhenAll(runtimePropsTask, queuePropsTask).ConfigureAwait(false);
+        var runtimeProps = await runtimePropsTask;
+        var queueProps = await queuePropsTask;
+
+        return runtimeProps.Value.ToQueueProperties(this, queueProps.Value.MaxSizeInMegabytes);
     }
 
     public Task Delete(string path, CancellationToken ct)

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage.Management/KnightBus.Azure.Storage.Management.csproj
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage.Management/KnightBus.Azure.Storage.Management.csproj
@@ -9,7 +9,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>4.0.0$(VersionSuffix)</Version>
+    <Version>4.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;azure storage;blob;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage.Management/StorageQueueExtensions.cs
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage.Management/StorageQueueExtensions.cs
@@ -27,7 +27,7 @@ public static class StorageQueueExtensions
         services = services
             .AddScoped<StorageQueueManager>()
             .AddScoped<IQueueManager, StorageQueueManager>()
-            .AddScoped<IQueueMessageAttachmentProvider, StorageQueueManager>();
+            .AddScoped<IQueueMessageAttachmentProvider, QueueMessageAttachmentProvider>();
 
         if (services.All(x => x.ServiceType != typeof(IMessageAttachmentProvider)))
         {

--- a/knightbus-azurestorage/src/KnightBus.Azure.Storage.Management/StorageQueueManager.cs
+++ b/knightbus-azurestorage/src/KnightBus.Azure.Storage.Management/StorageQueueManager.cs
@@ -12,22 +12,19 @@ using KnightBus.Core.PreProcessors;
 
 namespace KnightBus.Azure.Storage.Management;
 
-public class StorageQueueManager : IQueueManager, IQueueMessageAttachmentProvider
+public class StorageQueueManager : IQueueManager
 {
     private readonly IStorageBusConfiguration _configuration;
     private readonly IEnumerable<IMessagePreProcessor> _preProcessors;
     private readonly QueueServiceClient _client;
-    private readonly IMessageAttachmentProvider _attachmentProvider;
 
     public StorageQueueManager(
         IStorageBusConfiguration configuration,
-        IEnumerable<IMessagePreProcessor> preProcessors,
-        IMessageAttachmentProvider attachmentProvider
+        IEnumerable<IMessagePreProcessor> preProcessors
     )
     {
         _configuration = configuration;
         _preProcessors = preProcessors;
-        _attachmentProvider = attachmentProvider;
         _client = AzureStorageClientFactory.CreateQueueServiceClient(configuration);
     }
 
@@ -219,38 +216,4 @@ public class StorageQueueManager : IQueueManager, IQueueMessageAttachmentProvide
     }
 
     public QueueType QueueType => QueueType.Queue;
-
-    public async Task<QueueMessageAttachment> GetAttachment(
-        string queue,
-        Dictionary<string, string> messageProperties,
-        CancellationToken cancellationToken
-    )
-    {
-        var attachmentId = AttachmentUtility.GetAttachmentIds(messageProperties).FirstOrDefault();
-        if (string.IsNullOrEmpty(attachmentId))
-            return null;
-
-        var attachment = await _attachmentProvider.GetAttachmentAsync(
-            queue,
-            attachmentId,
-            cancellationToken
-        );
-
-        if (attachment is null)
-            return null;
-
-        return new QueueMessageAttachment(
-            attachment.Stream,
-            attachment.ContentType,
-            attachment.Filename,
-            attachment.Length
-        );
-    }
-
-    public bool HasAttachment(Dictionary<string, string> messageProperties)
-    {
-        return !string.IsNullOrEmpty(
-            AttachmentUtility.GetAttachmentIds(messageProperties).FirstOrDefault()
-        );
-    }
 }

--- a/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/StorageQueueManagerTests.cs
+++ b/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/StorageQueueManagerTests.cs
@@ -21,11 +21,7 @@ public class StorageQueueManagerTests : QueueManagerTests<TestCommand>
 
     public override async Task Setup()
     {
-        QueueManager = new StorageQueueManager(
-            _configuration,
-            Array.Empty<IMessagePreProcessor>(),
-            new BlobStorageMessageAttachmentProvider(_configuration)
-        );
+        QueueManager = new StorageQueueManager(_configuration, Array.Empty<IMessagePreProcessor>());
         QueueType = QueueType.Queue;
         var queues = await QueueManager.List(CancellationToken.None);
         foreach (var queue in queues)

--- a/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/StorageQueueMessageStateHandlerTests.cs
+++ b/knightbus-azurestorage/tests/KnightBus.Azure.Storage.Tests.Integration/StorageQueueMessageStateHandlerTests.cs
@@ -21,8 +21,7 @@ public class StorageQueueMessageStateHandlerTests : MessageStateHandlerTests<Tes
     {
         var queueManager = new StorageQueueManager(
             _configuration,
-            Array.Empty<IMessagePreProcessor>(),
-            new BlobStorageMessageAttachmentProvider(_configuration)
+            Array.Empty<IMessagePreProcessor>()
         );
 
         var queues = await queueManager.List(CancellationToken.None);

--- a/knightbus-postgresql/src/KnightBus.PostgreSql.Management.Extensions.Azure/KnightBus.PostgreSql.Management.Extensions.Azure.csproj
+++ b/knightbus-postgresql/src/KnightBus.PostgreSql.Management.Extensions.Azure/KnightBus.PostgreSql.Management.Extensions.Azure.csproj
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>3.0.1$(VersionSuffix)</Version>
+    <Version>3.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/knightbus-postgresql/src/KnightBus.PostgreSql.Management/KnightBus.PostgreSql.Management.csproj
+++ b/knightbus-postgresql/src/KnightBus.PostgreSql.Management/KnightBus.PostgreSql.Management.csproj
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>4.0.1$(VersionSuffix)</Version>
+    <Version>4.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/knightbus-redis/src/KnightBus.Redis.Management/KnightBus.Redis.Management.csproj
+++ b/knightbus-redis/src/KnightBus.Redis.Management/KnightBus.Redis.Management.csproj
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>3.0.0$(VersionSuffix)</Version>
+    <Version>3.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;redis;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/knightbus/src/KnightBus.Core.Management/KnightBus.Core.Management.csproj
+++ b/knightbus/src/KnightBus.Core.Management/KnightBus.Core.Management.csproj
@@ -10,11 +10,14 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>18.1.0$(VersionSuffix)</Version>
+    <Version>18.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include="knighbus-64.png" Pack="true" Visible="false" PackagePath="" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\KnightBus.Core\KnightBus.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/knightbus/src/KnightBus.Core.Management/QueueMessageAttachmentProvider.cs
+++ b/knightbus/src/KnightBus.Core.Management/QueueMessageAttachmentProvider.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace KnightBus.Core.Management;
+
+public class QueueMessageAttachmentProvider(IMessageAttachmentProvider attachmentProvider)
+    : IQueueMessageAttachmentProvider
+{
+    public async Task<QueueMessageAttachment> GetAttachment(
+        string queue,
+        Dictionary<string, string> messageProperties,
+        CancellationToken cancellationToken
+    )
+    {
+        var attachmentId = AttachmentUtility.GetAttachmentIds(messageProperties).FirstOrDefault();
+        if (string.IsNullOrEmpty(attachmentId))
+            return null;
+
+        var attachment = await attachmentProvider.GetAttachmentAsync(
+            queue,
+            attachmentId,
+            cancellationToken
+        );
+
+        if (attachment is null)
+            return null;
+
+        return new QueueMessageAttachment(
+            attachment.Stream,
+            attachment.ContentType,
+            attachment.Filename,
+            attachment.Length
+        );
+    }
+
+    public bool HasAttachment(Dictionary<string, string> messageProperties)
+    {
+        return !string.IsNullOrEmpty(
+            AttachmentUtility.GetAttachmentIds(messageProperties).FirstOrDefault()
+        );
+    }
+}

--- a/knightbus/src/KnightBus.Core.Management/QueueProperties.cs
+++ b/knightbus/src/KnightBus.Core.Management/QueueProperties.cs
@@ -33,6 +33,7 @@ public class QueueProperties
     public long TransferMessageCount { get; init; }
     public long TransferDeadLetterMessageCount { get; init; }
     public long SizeInBytes { get; init; }
+    public long? MaxSizeInMegabytes { get; init; }
     public DateTimeOffset CreatedAt { get; init; }
     public DateTimeOffset UpdatedAt { get; init; }
     public DateTimeOffset AccessedAt { get; init; }


### PR DESCRIPTION
- `IQueueMessageAttachmentProvider` (introduced in #144) was applied to StorageQueueManager. Attachments are however transport agnostic. With the current implementation `ServiceBusQueueManager` cannot get blob attachments for messages in `ServiceBus`. Remove `IQueueMessageAttachmentProvider` from `StorageQueueManager`, create a new class called `QueueMessageAttachmentProvider` that takes `IMessageAttachmentProvider` as its only dependency. This allows us to call `QueueMessageAttachmentProvider` regardless of transport
- return max queue size in `QueueProperties` (service bus only)