### PR TITLE
fix(knightbus): keep the message pump alive when CreateChannel fails

### DIFF
--- a/knightbus/src/KnightBus.Core/GenericMessagePump.cs
+++ b/knightbus/src/KnightBus.Core/GenericMessagePump.cs
@@ -52,8 +52,24 @@ public abstract class GenericMessagePump<TInternalRepresentation, TMessageInterf
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    if (!await PumpAsync<TMessage>(action, cancellationToken).ConfigureAwait(false))
+                    try
+                    {
+                        if (
+                            !await PumpAsync<TMessage>(action, cancellationToken)
+                                .ConfigureAwait(false)
+                        )
+                            await DelayPolling().ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        //The pump task is never awaited, so an escaping exception would kill the pump silently
+                        Log.LogError(
+                            e,
+                            "Unhandled error in message pump for {MessageType}",
+                            typeof(TMessage)
+                        );
                         await DelayPolling().ConfigureAwait(false);
+                    }
                 }
             },
             CancellationToken.None
@@ -154,7 +170,18 @@ public abstract class GenericMessagePump<TInternalRepresentation, TMessageInterf
             if (ShouldCreateChannel(e))
             {
                 Log.LogInformation("{MessageType} not found. Creating.", typeof(TMessage).Name);
-                await CreateChannel(typeof(TMessage));
+                try
+                {
+                    await CreateChannel(typeof(TMessage)).ConfigureAwait(false);
+                }
+                catch (Exception createException)
+                {
+                    Log.LogError(
+                        createException,
+                        "Failed to create channel for {MessageType}",
+                        typeof(TMessage)
+                    );
+                }
                 return false;
             }
 

--- a/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
+++ b/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>18.0.0$(VersionSuffix)</Version>
+    <Version>18.0.1$(VersionSuffix)</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/GenericMessagePumpTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/GenericMessagePumpTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using KnightBus.Messages;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+
+namespace KnightBus.Core.Tests.Unit;
+
+[TestFixture]
+public class GenericMessagePumpTests
+{
+    private class ChannelMissingException : Exception { }
+
+    private class TestPumpSettings : IProcessingSettings
+    {
+        public int MaxConcurrentCalls => 1;
+        public int PrefetchCount => 0;
+        public TimeSpan MessageLockTimeout => TimeSpan.FromMinutes(1);
+        public int DeadLetterDeliveryLimit => 1;
+    }
+
+    private class RecordingLogger : ILogger
+    {
+        public readonly ConcurrentQueue<(
+            LogLevel Level,
+            Exception Exception,
+            string Message
+        )> Entries = new();
+
+        public IDisposable BeginScope<TState>(TState state) => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception exception,
+            Func<TState, Exception, string> formatter
+        )
+        {
+            Entries.Enqueue((logLevel, exception, formatter(state, exception)));
+        }
+    }
+
+    private class TestMessagePump : GenericMessagePump<TestCommand, ICommand>
+    {
+        private readonly Func<Task> _createChannel;
+        private int _getMessagesInvocations;
+        private int _createChannelInvocations;
+        private volatile bool _channelCreated;
+
+        public int CreateChannelInvocations => _createChannelInvocations;
+        public int GetMessagesInvocations => _getMessagesInvocations;
+
+        public TestMessagePump(ILogger log, Func<Task> createChannel = null)
+            : base(new TestPumpSettings(), log)
+        {
+            _createChannel = createChannel;
+        }
+
+        protected override async IAsyncEnumerable<TestCommand> GetMessagesAsync<TMessage>(
+            int count,
+            TimeSpan? lockDuration
+        )
+        {
+            Interlocked.Increment(ref _getMessagesInvocations);
+            if (!_channelCreated)
+                throw new ChannelMissingException();
+            await Task.CompletedTask;
+            yield return new TestCommand();
+        }
+
+        protected override async Task CreateChannel(Type messageType)
+        {
+            Interlocked.Increment(ref _createChannelInvocations);
+            if (_createChannel != null)
+                await _createChannel();
+            _channelCreated = true;
+        }
+
+        protected override bool ShouldCreateChannel(Exception e) => e is ChannelMissingException;
+
+        protected override Task CleanupResources() => Task.CompletedTask;
+
+        protected override TimeSpan PollingDelay => TimeSpan.FromMilliseconds(10);
+
+        protected override int MaxFetch => 10;
+    }
+
+    [Test]
+    public async Task Should_not_throw_from_pump_when_create_channel_fails()
+    {
+        //arrange
+        var log = new RecordingLogger();
+        var pump = new TestMessagePump(
+            log,
+            () => throw new InvalidOperationException("create failed")
+        );
+
+        //act
+        var result = await pump.PumpAsync<TestCommand>(
+            (_, _) => Task.CompletedTask,
+            CancellationToken.None
+        );
+
+        //assert
+        result.Should().BeFalse();
+        log.Entries.Should()
+            .Contain(
+                e => e.Level == LogLevel.Error && e.Exception is InvalidOperationException,
+                "a failed channel creation must be logged, not swallowed or rethrown"
+            );
+    }
+
+    [Test]
+    public async Task Should_keep_polling_when_create_channel_fails_transiently()
+    {
+        //arrange: first CreateChannel attempt fails, second succeeds
+        var failures = 0;
+        var pump = new TestMessagePump(
+            new RecordingLogger(),
+            () =>
+                Interlocked.Increment(ref failures) == 1
+                    ? throw new InvalidOperationException("create failed")
+                    : Task.CompletedTask
+        );
+        var processed = new TaskCompletionSource();
+        using var cts = new CancellationTokenSource();
+
+        //act
+        await pump.StartAsync<TestCommand>(
+            (_, _) =>
+            {
+                processed.TrySetResult();
+                return Task.CompletedTask;
+            },
+            cts.Token
+        );
+
+        //assert: the pump must survive the failed creation, retry and process a message
+        await processed
+            .Task.WaitAsync(TimeSpan.FromSeconds(5))
+            .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        cts.Cancel();
+        processed
+            .Task.IsCompletedSuccessfully.Should()
+            .BeTrue("the pump loop must not die when CreateChannel throws");
+        pump.CreateChannelInvocations.Should().Be(2);
+    }
+}


### PR DESCRIPTION
## Problem

When `PumpAsync` catches an exception and `ShouldCreateChannel(e)` is true, it awaits `CreateChannel` **inside the catch block** with no guard. If that call throws — a transient DB/network error, or two hosts racing to create the same channel (Postgres `CREATE TABLE IF NOT EXISTS` can still fail on the `pg_type` race) — the exception escapes `PumpAsync`, unwinds the `while` loop in `StartAsync`, and faults the fire-and-forget `_runningTask` that nothing observes.

The result: the receiver dies **permanently and silently**. No log line, no retry, and the host keeps running (the TCP alive listener still answers), so the queue just stops being consumed.

## Fix

Two layers in `GenericMessagePump`:

1. **Guard `CreateChannel`**: a failed creation is logged at Error and `PumpAsync` returns `false`, so the pump backs off via the normal `DelayPolling` and retries — transient failures self-heal.
2. **Guard the pump loop**: since `_runningTask` is never awaited, the `StartAsync` loop now catches, logs, and delays on any escaping exception instead of dying unobserved. Defense in depth for future escape paths.

## Tests

New `GenericMessagePumpTests` (first direct unit tests for the generic pump). Both reproduce the bug against the previous code:

- `Should_not_throw_from_pump_when_create_channel_fails` — previously the exception escaped `PumpAsync` (failed); now returns `false` and logs the error.
- `Should_keep_polling_when_create_channel_fails_transiently` — previously the pump died after the first failed `CreateChannel` and never processed a message (failed); now it retries, creates the channel on the second attempt, and processes.

`KnightBus.Core.Tests.Unit` 40/40 and `KnightBus.Host.Tests.Unit` 37/37 pass. Files formatted with csharpier 1.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)