### PR TITLE
fix(knightbus): don't leak concurrency slots when message lock expires before processing starts

### DIFF
--- a/knightbus/src/KnightBus.Core/GenericMessagePump.cs
+++ b/knightbus/src/KnightBus.Core/GenericMessagePump.cs
@@ -136,24 +136,21 @@ public abstract class GenericMessagePump<TInternalRepresentation, TMessageInterf
 
                 messageCount++;
 #pragma warning disable 4014 //No need to await the result, let's keep the pump going
-                Task.Run(
-                        async () =>
+                //No scheduling token here: if the lock timeout fired before the task started,
+                //the delegate would be skipped and the finally would never release the slot
+                Task.Run(async () =>
+                    {
+                        try
                         {
-                            try
-                            {
-                                await action
-                                    .Invoke(message, linkedToken.Token)
-                                    .ConfigureAwait(false);
-                            }
-                            finally
-                            {
-                                _maxConcurrent.Release();
-                                timeoutToken.Dispose();
-                                linkedToken.Dispose();
-                            }
-                        },
-                        timeoutToken.Token
-                    )
+                            await action.Invoke(message, linkedToken.Token).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            _maxConcurrent.Release();
+                            timeoutToken.Dispose();
+                            linkedToken.Dispose();
+                        }
+                    })
                     .ConfigureAwait(false);
 #pragma warning restore 4014
             }

--- a/knightbus/src/KnightBus.Core/GenericMessagePump.cs
+++ b/knightbus/src/KnightBus.Core/GenericMessagePump.cs
@@ -138,19 +138,24 @@ public abstract class GenericMessagePump<TInternalRepresentation, TMessageInterf
 #pragma warning disable 4014 //No need to await the result, let's keep the pump going
                 //No scheduling token here: if the lock timeout fired before the task started,
                 //the delegate would be skipped and the finally would never release the slot
-                Task.Run(async () =>
-                    {
-                        try
+                Task.Run(
+                        async () =>
                         {
-                            await action.Invoke(message, linkedToken.Token).ConfigureAwait(false);
-                        }
-                        finally
-                        {
-                            _maxConcurrent.Release();
-                            timeoutToken.Dispose();
-                            linkedToken.Dispose();
-                        }
-                    })
+                            try
+                            {
+                                await action
+                                    .Invoke(message, linkedToken.Token)
+                                    .ConfigureAwait(false);
+                            }
+                            finally
+                            {
+                                _maxConcurrent.Release();
+                                timeoutToken.Dispose();
+                                linkedToken.Dispose();
+                            }
+                        },
+                        CancellationToken.None
+                    )
                     .ConfigureAwait(false);
 #pragma warning restore 4014
             }

--- a/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
+++ b/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>18.0.1$(VersionSuffix)</Version>
+    <Version>18.0.2$(VersionSuffix)</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/GenericMessagePumpTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/GenericMessagePumpTests.cs
@@ -152,4 +152,107 @@ public class GenericMessagePumpTests
             .BeTrue("the pump loop must not die when CreateChannel throws");
         pump.CreateChannelInvocations.Should().Be(2);
     }
+
+    private class ExpiringLockPumpSettings : IProcessingSettings
+    {
+        public int MaxConcurrentCalls { get; init; } = 4;
+        public int PrefetchCount => 0;
+        public TimeSpan MessageLockTimeout { get; init; }
+        public int DeadLetterDeliveryLimit => 1;
+    }
+
+    private class ExpiringLockMessagePump : GenericMessagePump<TestCommand, ICommand>
+    {
+        private readonly TimeSpan _fetchDelay;
+        private readonly int _messagesPerFetch;
+
+        public ExpiringLockMessagePump(
+            IProcessingSettings settings,
+            TimeSpan fetchDelay,
+            int messagesPerFetch
+        )
+            : base(settings, new RecordingLogger())
+        {
+            _fetchDelay = fetchDelay;
+            _messagesPerFetch = messagesPerFetch;
+        }
+
+        protected override async IAsyncEnumerable<TestCommand> GetMessagesAsync<TMessage>(
+            int count,
+            TimeSpan? lockDuration
+        )
+        {
+            //Burn almost the entire message lock before yielding, so every message is
+            //dispatched with only a sliver of its lock duration remaining
+            Thread.Sleep(_fetchDelay);
+            for (var i = 0; i < _messagesPerFetch; i++)
+            {
+                yield return new TestCommand();
+            }
+            await Task.CompletedTask;
+        }
+
+        protected override Task CreateChannel(Type messageType) => Task.CompletedTask;
+
+        protected override bool ShouldCreateChannel(Exception e) => false;
+
+        protected override Task CleanupResources() => Task.CompletedTask;
+
+        protected override TimeSpan PollingDelay => TimeSpan.FromMilliseconds(1);
+
+        protected override int MaxFetch => 10;
+    }
+
+    [Test]
+    public async Task Should_not_leak_concurrency_slots_when_lock_expires_before_processing_starts()
+    {
+        const int maxConcurrent = 4;
+        const int rounds = 100;
+
+        for (var round = 0; round < rounds; round++)
+        {
+            var pump = new ExpiringLockMessagePump(
+                new ExpiringLockPumpSettings
+                {
+                    MaxConcurrentCalls = maxConcurrent,
+                    MessageLockTimeout = TimeSpan.FromMilliseconds(12),
+                },
+                fetchDelay: TimeSpan.FromMilliseconds(10),
+                messagesPerFetch: maxConcurrent
+            );
+
+            //Keep the thread pool queue busy so dispatched messages don't start instantly,
+            //letting the lock timeout win the race against the processing task starting
+            using var noiseCts = new CancellationTokenSource();
+            var noise = Task.Run(() =>
+            {
+                while (!noiseCts.IsCancellationRequested)
+                {
+                    for (var i = 0; i < 32; i++)
+                    {
+                        Task.Run(() => Thread.SpinWait(50_000));
+                    }
+                    Thread.Sleep(1);
+                }
+            });
+
+            await pump.PumpAsync<TestCommand>((_, _) => Task.CompletedTask, CancellationToken.None);
+            noiseCts.Cancel();
+            await noise;
+
+            //All slots must eventually come back, no matter how the lock-timeout race played out
+            var deadline = DateTime.UtcNow.AddSeconds(2);
+            while (pump.AvailableThreads < maxConcurrent && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(10);
+            }
+
+            pump.AvailableThreads.Should()
+                .Be(
+                    maxConcurrent,
+                    "a message whose lock expired before processing started must still release "
+                        + $"its concurrency slot (round {round})"
+                );
+        }
+    }
 }

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/GenericMessagePumpTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/GenericMessagePumpTests.cs
@@ -184,12 +184,20 @@ public class GenericMessagePumpTests
         {
             //Burn almost the entire message lock before yielding, so every message is
             //dispatched with only a sliver of its lock duration remaining
-            Thread.Sleep(_fetchDelay);
+            await Task.Delay(_fetchDelay, CancellationToken.None);
+
+            //Flood the thread pool queue right before yielding so the dispatched
+            //processing tasks queue up behind the burst and don't start instantly,
+            //letting the lock timeout win the race against the processing task starting
+            for (var i = 0; i < 512; i++)
+            {
+                _ = Task.Run(() => Thread.SpinWait(20_000), CancellationToken.None);
+            }
+
             for (var i = 0; i < _messagesPerFetch; i++)
             {
                 yield return new TestCommand();
             }
-            await Task.CompletedTask;
         }
 
         protected override Task CreateChannel(Type messageType) => Task.CompletedTask;
@@ -221,30 +229,13 @@ public class GenericMessagePumpTests
                 messagesPerFetch: maxConcurrent
             );
 
-            //Keep the thread pool queue busy so dispatched messages don't start instantly,
-            //letting the lock timeout win the race against the processing task starting
-            using var noiseCts = new CancellationTokenSource();
-            var noise = Task.Run(() =>
-            {
-                while (!noiseCts.IsCancellationRequested)
-                {
-                    for (var i = 0; i < 32; i++)
-                    {
-                        Task.Run(() => Thread.SpinWait(50_000));
-                    }
-                    Thread.Sleep(1);
-                }
-            });
-
             await pump.PumpAsync<TestCommand>((_, _) => Task.CompletedTask, CancellationToken.None);
-            noiseCts.Cancel();
-            await noise;
 
             //All slots must eventually come back, no matter how the lock-timeout race played out
             var deadline = DateTime.UtcNow.AddSeconds(2);
             while (pump.AvailableThreads < maxConcurrent && DateTime.UtcNow < deadline)
             {
-                await Task.Delay(10);
+                await Task.Delay(10, CancellationToken.None);
             }
 
             pump.AvailableThreads.Should()


### PR DESCRIPTION
## Problem

`GenericMessagePump.PumpAsync` dispatches each message with `Task.Run(delegate, timeoutToken.Token)`, where `timeoutToken` fires when the message's remaining lock duration runs out — which can be a sliver of milliseconds when the fetch consumed most of the lock window.

Passing that token as the **scheduling** token means that if it cancels before the thread pool starts the task (already-expired at dispatch, queued behind other work, pool starvation), the delegate is skipped entirely — including its `finally`, which releases the `_maxConcurrent` slot and disposes both `CancellationTokenSource`s.

Every occurrence permanently reduces the pump's effective `MaxConcurrentCalls`. Enough of them and the gate `WaitAsync` at the top of `PumpAsync` never returns: the pump deadlocks and the queue silently stops being consumed. Same bug family as the NATS semaphore leak fixed in `a95dd57`.

## Verification

New test `Should_not_leak_concurrency_slots_when_lock_expires_before_processing_starts`: dispatches messages with ~2 ms of lock remaining while keeping the thread pool queue busy, then asserts all slots return. Against the previous code it fails on the **first round** — `AvailableThreads` stuck at 3 of 4 after a 2-second settle window, i.e. one slot permanently lost.

## Fix

Drop the scheduling token from `Task.Run`. The delegate now always runs, so the slot is always released and the token sources always disposed. Behavior is otherwise unchanged: the action still receives the linked token, so an expired lock still cancels processing cooperatively (and flows into the normal abandon path).

## Tests

- New leak regression test passes 100 consecutive rounds (~1 s).
- `KnightBus.Core.Tests.Unit` 41/41, `KnightBus.Host.Tests.Unit` 37/37, `KnightBus.Azure.Storage.Tests.Unit` (pump consumers) 17/17.
- csharpier-formatted; KnightBus.Core bumped to **18.0.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)