### PR TITLE
fix(knightbus): call CleanupResources when the message pump stops

### DIFF
--- a/knightbus-postgresql/src/KnightBus.PostgreSql/KnightBus.PostgreSql.csproj
+++ b/knightbus-postgresql/src/KnightBus.PostgreSql/KnightBus.PostgreSql.csproj
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>3.0.0$(VersionSuffix)</Version>
+    <Version>3.0.1$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/knightbus-postgresql/src/KnightBus.PostgreSql/PostgresMessagePump.cs
+++ b/knightbus-postgresql/src/KnightBus.PostgreSql/PostgresMessagePump.cs
@@ -65,9 +65,11 @@ public class PostgresMessagePump<T> : GenericMessagePump<PostgresMessage<T>, IMe
         return e is PostgresException { SqlState: PostgresErrorCodes.UndefinedTable };
     }
 
-    protected override async Task CleanupResources()
+    protected override Task CleanupResources()
     {
-        await _npgsqlDataSource.DisposeAsync();
+        //The NpgsqlDataSource is a DI-owned singleton shared with other receivers, senders and
+        //the saga store, so it must not be disposed when a single pump stops
+        return Task.CompletedTask;
     }
 
     protected override TimeSpan PollingDelay => _postgresConfiguration.PollingDelay;

--- a/knightbus/src/KnightBus.Core/GenericMessagePump.cs
+++ b/knightbus/src/KnightBus.Core/GenericMessagePump.cs
@@ -71,6 +71,20 @@ public abstract class GenericMessagePump<TInternalRepresentation, TMessageInterf
                         await DelayPolling().ConfigureAwait(false);
                     }
                 }
+
+                try
+                {
+                    await CleanupResources().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    //The pump task is never awaited, so an escaping exception would be unobserved
+                    Log.LogError(
+                        e,
+                        "Failed to cleanup resources in message pump for {MessageType}",
+                        typeof(TMessage)
+                    );
+                }
             },
             CancellationToken.None
         );
@@ -218,7 +232,10 @@ public abstract class GenericMessagePump<TInternalRepresentation, TMessageInterf
     protected abstract bool ShouldCreateChannel(Exception e);
 
     /// <summary>
-    /// Cleanup any expensive resources when shutting down
+    /// Cleanup any expensive resources owned by this pump instance.
+    /// Called once when the pump loop has stopped after its cancellation token was cancelled.
+    /// Do not release resources shared with other components, since the pump can be stopped
+    /// while the rest of the host keeps running.
     /// </summary>
     protected abstract Task CleanupResources();
 

--- a/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
+++ b/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>18.0.2$(VersionSuffix)</Version>
+    <Version>18.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/GenericMessagePumpTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/GenericMessagePumpTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -50,17 +51,25 @@ public class GenericMessagePumpTests
     private class TestMessagePump : GenericMessagePump<TestCommand, ICommand>
     {
         private readonly Func<Task> _createChannel;
+        private readonly Func<Task> _cleanupResources;
         private int _getMessagesInvocations;
         private int _createChannelInvocations;
+        private int _cleanupResourcesInvocations;
         private volatile bool _channelCreated;
 
         public int CreateChannelInvocations => _createChannelInvocations;
         public int GetMessagesInvocations => _getMessagesInvocations;
+        public int CleanupResourcesInvocations => _cleanupResourcesInvocations;
 
-        public TestMessagePump(ILogger log, Func<Task> createChannel = null)
+        public TestMessagePump(
+            ILogger log,
+            Func<Task> createChannel = null,
+            Func<Task> cleanupResources = null
+        )
             : base(new TestPumpSettings(), log)
         {
             _createChannel = createChannel;
+            _cleanupResources = cleanupResources;
         }
 
         protected override async IAsyncEnumerable<TestCommand> GetMessagesAsync<TMessage>(
@@ -85,7 +94,12 @@ public class GenericMessagePumpTests
 
         protected override bool ShouldCreateChannel(Exception e) => e is ChannelMissingException;
 
-        protected override Task CleanupResources() => Task.CompletedTask;
+        protected override async Task CleanupResources()
+        {
+            Interlocked.Increment(ref _cleanupResourcesInvocations);
+            if (_cleanupResources != null)
+                await _cleanupResources();
+        }
 
         protected override TimeSpan PollingDelay => TimeSpan.FromMilliseconds(10);
 
@@ -151,6 +165,60 @@ public class GenericMessagePumpTests
             .Task.IsCompletedSuccessfully.Should()
             .BeTrue("the pump loop must not die when CreateChannel throws");
         pump.CreateChannelInvocations.Should().Be(2);
+    }
+
+    [Test]
+    public async Task Should_cleanup_resources_when_the_pump_stops()
+    {
+        //arrange
+        var pump = new TestMessagePump(new RecordingLogger());
+        using var cts = new CancellationTokenSource();
+        await pump.StartAsync<TestCommand>((_, _) => Task.CompletedTask, cts.Token);
+
+        //act
+        cts.Cancel();
+
+        //assert
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (pump.CleanupResourcesInvocations == 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10, CancellationToken.None);
+        }
+
+        pump.CleanupResourcesInvocations.Should()
+            .Be(1, "the pump must clean up its resources when it stops");
+    }
+
+    [Test]
+    public async Task Should_log_and_not_throw_when_cleanup_resources_fails()
+    {
+        //arrange
+        var log = new RecordingLogger();
+        var pump = new TestMessagePump(
+            log,
+            cleanupResources: () => throw new InvalidOperationException("cleanup failed")
+        );
+        using var cts = new CancellationTokenSource();
+        await pump.StartAsync<TestCommand>((_, _) => Task.CompletedTask, cts.Token);
+
+        //act
+        cts.Cancel();
+
+        //assert
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (
+            !log.Entries.Any(e => e.Exception is InvalidOperationException)
+            && DateTime.UtcNow < deadline
+        )
+        {
+            await Task.Delay(10, CancellationToken.None);
+        }
+
+        log.Entries.Should()
+            .Contain(
+                e => e.Level == LogLevel.Error && e.Exception is InvalidOperationException,
+                "a failed resource cleanup must be logged, not thrown unobserved"
+            );
     }
 
     private class ExpiringLockPumpSettings : IProcessingSettings


### PR DESCRIPTION
## Problem

`CleanupResources()` is abstract on `GenericMessagePump` — documented as *"Cleanup any expensive resources when shutting down"* — and implemented by all three pump-based transports (Redis, Azure Storage, PostgreSql). But **no code path has ever invoked it**.

Verified exhaustively:
- Repo-wide search: the only references are the abstract declaration and the three overrides — zero call sites.
- It's `protected abstract`, so the host/receivers couldn't call it even in principle (it's not on `IChannelReceiver` or any interface), and no subclass calls it.
- No reflection-based invocation (`nameof`, `GetMethod`, string literal): zero hits.
- Git history (`git log --all -S`): no commit ever added or removed a call — dead since it was introduced in #112.

## Fix

**Core**: the pump now calls `CleanupResources()` once, when the pump loop exits after its cancellation token is cancelled. Failures are logged instead of faulting the unobserved pump task. The XML doc now states when it runs and warns against releasing shared resources — because a pump can stop (e.g. singleton lock loss) while the rest of the host keeps running.

**PostgreSql**: wiring the call in exposed a latent bug — `PostgresMessagePump.CleanupResources` disposed the `NpgsqlDataSource`, which is a **DI-owned singleton shared** with every other Postgres receiver, the `IPostgresBus` sender and the saga store (`AddNpgsqlDataSource` in `UsePostgres`). Had the contract been honored as written, one pump stopping would have broken all of them. It's now an explicit no-op; the container owns the data source's lifetime. Redis and Storage cleanups were already no-ops and need no change.

All three transports create a fresh pump per `StartAsync`, so cleanup-on-stop is safe with the singleton receiver's stop/restart cycle.

## Tests

- `Should_cleanup_resources_when_the_pump_stops` — cleanup runs exactly once after cancellation.
- `Should_log_and_not_throw_when_cleanup_resources_fails` — a throwing cleanup is logged at Error, not left as an unobserved task fault.
- `KnightBus.Core.Tests.Unit` 43/43, `KnightBus.Host.Tests.Unit` 37/37, `KnightBus.Azure.Storage.Tests.Unit` 17/17, `KnightBus.Redis.Tests.Unit` 2/2; PostgreSql builds clean (only pre-existing NU1510 warnings).

## Versions

- KnightBus.Core **18.1.0** (an extension point changes behavior: implementations are now actually invoked)
- KnightBus.PostgreSql **3.0.1**

🤖 Generated with [Claude Code](https://claude.com/claude-code)