### PR TITLE
fix(knightbus): drain the leak test's thread pool burst so it cannot starve later tests

### DIFF
--- a/knightbus/tests/KnightBus.Core.Tests.Unit/GenericMessagePumpTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/GenericMessagePumpTests.cs
@@ -234,6 +234,10 @@ public class GenericMessagePumpTests
         private readonly TimeSpan _fetchDelay;
         private readonly int _messagesPerFetch;
 
+        //Tracked so the test can drain the burst, orphaned work items starve the thread
+        //pool queue for tests running after this one on machines with few cores
+        public readonly List<Task> NoiseTasks = new();
+
         public ExpiringLockMessagePump(
             IProcessingSettings settings,
             TimeSpan fetchDelay,
@@ -259,7 +263,7 @@ public class GenericMessagePumpTests
             //letting the lock timeout win the race against the processing task starting
             for (var i = 0; i < 512; i++)
             {
-                _ = Task.Run(() => Thread.SpinWait(20_000), CancellationToken.None);
+                NoiseTasks.Add(Task.Run(() => Thread.SpinWait(20_000), CancellationToken.None));
             }
 
             for (var i = 0; i < _messagesPerFetch; i++)
@@ -312,6 +316,10 @@ public class GenericMessagePumpTests
                     "a message whose lock expired before processing started must still release "
                         + $"its concurrency slot (round {round})"
                 );
+
+            //Drain the noise burst before the next round so it cannot pile up and starve
+            //the thread pool for tests that run after this one
+            await Task.WhenAll(pump.NoiseTasks);
         }
     }
 }


### PR DESCRIPTION
## Problem

Master's CI build fails on the two `SingletonTimerScopeTests` added in #193 (both time out after 5 s). The tests are innocent — the culprit is the concurrency-slot leak regression test from #191 in the same assembly.

That test floods the thread pool with 512 fire-and-forget `Thread.SpinWait(20_000)` work items per round (×100 rounds) to delay message dispatch. It relied on an implicit drain: the dispatched message tasks are queued *behind* the burst, and the round's settle-poll waits for them, so each round consumed its own burst. But `PumpAsync` has an early exit — when the fetch delay overshoots the 12 ms lock budget (`remainingLockDuration <= TimeSpan.Zero`), the round returns **without dispatching anything**, and nothing forces the burst to drain.

On a contended 2-vCPU runner (four parallel test hosts plus Docker containers), `Task.Delay(10ms)` routinely overshoots 12 ms, so round after round orphans its full burst — up to 51,200 spin items jam the test process's global queue. The leak test still passes (6 s on the failing run) and leaves the backlog behind; the `SingletonTimerScopeTests` `Task.Run` work items then queue behind it while their `WaitAsync` timeout timers (high-priority queue in .NET 9+) jump ahead and fire — exactly the observed failures. Unreproducible on a fast local machine because the 10 ms delay never overshoots there, so every round self-drains.

## Fix

The burst tasks are tracked and awaited at the end of every round, so the drain no longer depends on messages having been dispatched and the fixture always exits with an empty pool queue.

Core suite passes in Release, both normally and under `DOTNET_PROCESSOR_COUNT=2` (45/45). Test-only change, no version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)