### PR TITLE
fix(knightbus): don't let a failed saga delete mask the handler's exception

### DIFF
--- a/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
+++ b/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>18.2.0$(VersionSuffix)</Version>
+    <Version>18.2.1$(VersionSuffix)</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/knightbus/src/KnightBus.Core/Sagas/SagaMiddleWare.cs
+++ b/knightbus/src/KnightBus.Core/Sagas/SagaMiddleWare.cs
@@ -79,9 +79,23 @@ public class SagaMiddleware : IMessageProcessorMiddleware
                 if (saga.MessageMapper.IsStartMessage(typeof(T)))
                 {
                     //If we have started a saga but the start message fails then we must make sure the message can be retried
-                    await _sagaStore
-                        .Delete(saga.PartitionKey, saga.Id, cancellationToken)
-                        .ConfigureAwait(false);
+                    try
+                    {
+                        await _sagaStore
+                            .Delete(saga.PartitionKey, saga.Id, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    catch (Exception deleteException)
+                    {
+                        //The handler's exception must surface, not the cleanup failure.
+                        //Retries will see the saga as already started until the saga expires.
+                        pipelineInformation.HostConfiguration.Log.LogWarning(
+                            deleteException,
+                            "Failed to delete saga {PartitionKey} {SagaId} after the start message failed",
+                            saga.PartitionKey,
+                            saga.Id
+                        );
+                    }
                 }
                 throw;
             }

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/SagaMiddlewareTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/SagaMiddlewareTests.cs
@@ -220,6 +220,65 @@ public class SagaMiddlewareTests
         saga.Data.Data.Should().Be("loaded");
     }
 
+    [Test]
+    public async Task Should_rethrow_handler_exception_when_saga_delete_fails()
+    {
+        //arrange: the start message handler fails, and the cleanup delete also fails
+        var partitionKey = "a";
+        var id = "b";
+        var sagaStore = new Mock<ISagaStore>();
+        sagaStore
+            .Setup(x =>
+                x.Create(
+                    partitionKey,
+                    id,
+                    It.IsAny<SagaData>(),
+                    TimeSpan.FromHours(1),
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync(new SagaData<SagaData> { Data = new SagaData() });
+        sagaStore
+            .Setup(x => x.Delete(partitionKey, id, CancellationToken.None))
+            .ThrowsAsync(new TimeoutException("delete failed"));
+
+        var di = new Mock<IDependencyInjection>();
+        di.Setup(x => x.GetInstance<object>(typeof(IProcessCommand<SagaStartMessage, Settings>)))
+            .Returns(new Saga());
+
+        var hostConfiguration = new Mock<IHostConfiguration>();
+        hostConfiguration.Setup(x => x.Log).Returns(Mock.Of<ILogger>());
+        hostConfiguration.Setup(x => x.DependencyInjection).Returns(di.Object);
+        var messageStateHandler = new Mock<IMessageStateHandler<SagaStartMessage>>();
+        messageStateHandler.Setup(x => x.MessageScope).Returns(di.Object);
+        var pipelineInformation = new Mock<IPipelineInformation>();
+        pipelineInformation.Setup(x => x.HostConfiguration).Returns(hostConfiguration.Object);
+        pipelineInformation
+            .Setup(x => x.ProcessorInterfaceType)
+            .Returns(typeof(IProcessCommand<SagaStartMessage, Settings>));
+        var next = new Mock<IMessageProcessor>();
+        next.Setup(x => x.ProcessAsync(messageStateHandler.Object, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("handler failed"));
+
+        var middleware = new SagaMiddleware(sagaStore.Object);
+
+        //act & assert: the handler's exception must surface, not the cleanup failure
+        await middleware
+            .Awaiting(x =>
+                x.ProcessAsync(
+                    messageStateHandler.Object,
+                    pipelineInformation.Object,
+                    next.Object,
+                    CancellationToken.None
+                )
+            )
+            .Should()
+            .ThrowAsync<InvalidOperationException>(
+                "the failure that caused the retry must not be masked by the saga cleanup failing"
+            );
+        sagaStore.Verify(x => x.Delete(partitionKey, id, CancellationToken.None), Times.Once);
+    }
+
     public class Saga : Saga<SagaData>, IProcessCommand<SagaStartMessage, Settings>
     {
         public override TimeSpan TimeToLive => TimeSpan.FromHours(1);


### PR DESCRIPTION
## Problem

When a saga start message fails, `SagaMiddleware` deletes the saga so the retry can re-create it — but the delete ran **unguarded inside the catch block**. A transient store failure there replaced the handler's original exception, with two consequences:

1. The log blamed the saga store instead of the actual handler failure.
2. The saga row survived, so **every retry hit `SagaAlreadyStartedException` and completed the message as a "duplicate"** — the message was consumed even though the work never succeeded.

## Verification

New test `Should_rethrow_handler_exception_when_saga_delete_fails`: handler throws `InvalidOperationException`, the cleanup `Delete` throws `TimeoutException`. Against master it fails with exactly the masking behavior — `Expected InvalidOperationException ... but found TimeoutException: delete failed`.

## Fix

The delete is wrapped in its own try/catch: the failure is logged as a warning (with the saga's partition key and id) and the handler's exception is rethrown. When the delete fails, retries will see the saga as already started until it expires via its TTL — that pre-existing consequence is now at least visible in the log instead of silently consuming the message with a misattributed error.

## Tests

`KnightBus.Core.Tests.Unit` 48/48, `KnightBus.Host.Tests.Unit` 50/50. csharpier clean.

## Versions

- KnightBus.Core **18.2.1**

🤖 Generated with [Claude Code](https://claude.com/claude-code)