### PR TITLE
fix(knightbus): attachment cleanup must not dispose twice or fail completed messages

### DIFF
--- a/knightbus/src/KnightBus.Core/DefaultMiddlewares/AttachmentMiddleware.cs
+++ b/knightbus/src/KnightBus.Core/DefaultMiddlewares/AttachmentMiddleware.cs
@@ -1,10 +1,20 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using KnightBus.Messages;
+using Microsoft.Extensions.Logging;
 
 namespace KnightBus.Core.DefaultMiddlewares;
 
+/// <summary>
+/// Loads the attachment for <see cref="ICommandWithAttachment"/> messages before processing and
+/// deletes it after the message has been successfully processed.
+/// The attachment is kept when processing fails, since a retry needs it, and when the message is
+/// dead lettered, so the message can be inspected or requeued with its attachment intact.
+/// Attachments of dead lettered messages are never cleaned up by KnightBus; use a lifecycle
+/// policy in the attachment store when they must expire.
+/// </summary>
 public class AttachmentMiddleware : IMessageProcessorMiddleware
 {
     private readonly IMessageAttachmentProvider _attachmentProvider;
@@ -45,10 +55,24 @@ public class AttachmentMiddleware : IMessageProcessorMiddleware
             await next.ProcessAsync(messageStateHandler, cancellationToken).ConfigureAwait(false);
             if (attachment != null)
             {
-                attachment.Stream?.Dispose();
-                await _attachmentProvider
-                    .DeleteAttachmentAsync(queueName, attachmentId, cancellationToken)
-                    .ConfigureAwait(false);
+                try
+                {
+                    await _attachmentProvider
+                        .DeleteAttachmentAsync(queueName, attachmentId, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    //The message is already completed when the delete runs, so throwing here
+                    //would only trigger a failed abandon of a completed message. The attachment
+                    //is orphaned and must be cleaned up by the attachment store
+                    pipelineInformation?.HostConfiguration?.Log?.LogWarning(
+                        e,
+                        "Failed to delete attachment {AttachmentId} for {QueueName}",
+                        attachmentId,
+                        queueName
+                    );
+                }
             }
         }
         finally

--- a/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
+++ b/knightbus/src/KnightBus.Core/KnightBus.Core.csproj
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>18.2.1$(VersionSuffix)</Version>
+    <Version>18.2.2$(VersionSuffix)</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/knightbus/tests/KnightBus.Core.Tests.Unit/AttachmentMiddlewareTests.cs
+++ b/knightbus/tests/KnightBus.Core.Tests.Unit/AttachmentMiddlewareTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -6,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using KnightBus.Core.DefaultMiddlewares;
 using KnightBus.Messages;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 
@@ -106,6 +108,130 @@ public class AttachmentMiddlewareTests
                 ),
             Times.Once
         );
+    }
+
+    [Test]
+    public async Task Should_dispose_the_attachment_stream_exactly_once()
+    {
+        //arrange
+        var message = new AttachmentCommand();
+        var nextProcessor = new Mock<IMessageProcessor>();
+        var stream = new DisposeCountingStream();
+        var attachment = new MessageAttachment("test.txt", "text/plain", stream);
+        var stateHandler = new Mock<IMessageStateHandler<AttachmentCommand>>();
+        stateHandler.Setup(x => x.GetMessage()).Returns(message);
+        stateHandler
+            .Setup(x => x.MessageProperties)
+            .Returns(
+                new Dictionary<string, string>
+                {
+                    { AttachmentUtility.AttachmentKey, "89BDF3DB-896C-448D-A84E-872CBA8DBC9F" },
+                }
+            );
+        var attachmentProvider = new Mock<IMessageAttachmentProvider>();
+        attachmentProvider
+            .Setup(x =>
+                x.GetAttachmentAsync(
+                    AutoMessageMapper.GetQueueName<AttachmentCommand>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(attachment);
+        var middleware = new AttachmentMiddleware(attachmentProvider.Object);
+
+        //act
+        await middleware.ProcessAsync(
+            stateHandler.Object,
+            Mock.Of<IPipelineInformation>(),
+            nextProcessor.Object,
+            CancellationToken.None
+        );
+
+        //assert
+        stream.DisposeCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task Should_not_throw_when_attachment_delete_fails()
+    {
+        //arrange: by the time the attachment is deleted the message is already completed,
+        //so a delete failure must not escape into the error handling and trigger an abandon
+        var message = new AttachmentCommand();
+        var nextProcessor = new Mock<IMessageProcessor>();
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes("this is a stream"));
+        var attachment = new MessageAttachment("test.txt", "text/plain", stream);
+        var stateHandler = new Mock<IMessageStateHandler<AttachmentCommand>>();
+        stateHandler.Setup(x => x.GetMessage()).Returns(message);
+        stateHandler
+            .Setup(x => x.MessageProperties)
+            .Returns(
+                new Dictionary<string, string>
+                {
+                    { AttachmentUtility.AttachmentKey, "89BDF3DB-896C-448D-A84E-872CBA8DBC9F" },
+                }
+            );
+        var attachmentProvider = new Mock<IMessageAttachmentProvider>();
+        attachmentProvider
+            .Setup(x =>
+                x.GetAttachmentAsync(
+                    AutoMessageMapper.GetQueueName<AttachmentCommand>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(attachment);
+        attachmentProvider
+            .Setup(x =>
+                x.DeleteAttachmentAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ThrowsAsync(new TimeoutException("delete failed"));
+        var log = new Mock<ILogger>();
+        var hostConfiguration = new Mock<IHostConfiguration>();
+        hostConfiguration.Setup(x => x.Log).Returns(log.Object);
+        var pipelineInformation = new Mock<IPipelineInformation>();
+        pipelineInformation.Setup(x => x.HostConfiguration).Returns(hostConfiguration.Object);
+        var middleware = new AttachmentMiddleware(attachmentProvider.Object);
+
+        //act & assert
+        await middleware
+            .Awaiting(x =>
+                x.ProcessAsync(
+                    stateHandler.Object,
+                    pipelineInformation.Object,
+                    nextProcessor.Object,
+                    CancellationToken.None
+                )
+            )
+            .Should()
+            .NotThrowAsync("the message is already completed when the delete runs");
+        log.Verify(
+            x =>
+                x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => true),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()
+                ),
+            Times.Once,
+            "the orphaned attachment must be visible in the log"
+        );
+    }
+
+    private class DisposeCountingStream : MemoryStream
+    {
+        public int DisposeCount { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCount++;
+            base.Dispose(disposing);
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Problems

Three related issues in `AttachmentMiddleware`, from the core review:

1. **Double dispose** — the attachment stream was disposed after processing *and* again in the `finally`. Harmless for `MemoryStream` (which is why existing tests never caught it) but not guaranteed harmless for provider streams.
2. **Delete failure after completion** — `DeleteAttachmentAsync` runs *after* the inner processor has already completed the message. A transient delete failure escaped into `ErrorHandlingMiddleware`, which then attempted `AbandonByErrorAsync` on an already-completed message — a guaranteed transport error and a misleading log blaming message processing for a cleanup failure. Same family as #196's saga fix: cleanup failures must not corrupt the outcome of successful processing.
3. **Orphaned attachments on dead-letter, undocumented** — `DeadLetterMiddleware` short-circuits before this middleware, so dead-lettered messages keep their attachments forever. That behavior is actually **correct** — `MoveDeadLetters` requeues messages with their attachment id intact, and management tooling reads attachments of dead-lettered messages — so this PR documents it as intentional rather than "fixing" it, including that expiry is the attachment store's responsibility (lifecycle policy).

## Verification

Both fixes verified red→green:
- `Should_dispose_the_attachment_stream_exactly_once` — a dispose-counting stream measured **2** disposals on master.
- `Should_not_throw_when_attachment_delete_fails` — on master the `TimeoutException` from the delete escaped the middleware; now it's swallowed and logged as a warning naming the orphaned attachment id and queue.

## Fix

Stream disposed once, in the `finally`. The delete is guarded; failures log a warning via the pipeline's host logger (null-safe, matching `ThrottlingMiddleware`'s pattern). XML docs on the class describe the full attachment lifecycle: deleted on success, kept on failure (retries need it), kept on dead-letter (inspection/requeue), orphans cleaned by store policy.

## Tests

`KnightBus.Core.Tests.Unit` 50/50, `KnightBus.Azure.Storage.Tests.Unit` 17/17. csharpier clean.

## Versions

- KnightBus.Core **18.2.2**

🤖 Generated with [Claude Code](https://claude.com/claude-code)