### PR TITLE
fix(knightbus): synchronize the singleton lock polling flag and ignore stale watchers

### DIFF
--- a/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
+++ b/knightbus/src/KnightBus.Host/KnightBus.Host.csproj
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BookBeat/knightbus/master/documentation/media/images/knighbus-64.png</PackageIconUrl>
     <PackageIcon>knighbus-64.png</PackageIcon>
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
-    <Version>18.1.0$(VersionSuffix)</Version>
+    <Version>18.1.1$(VersionSuffix)</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/knightbus/src/KnightBus.Host/Singleton/SingletonChannelReceiver.cs
+++ b/knightbus/src/KnightBus.Host/Singleton/SingletonChannelReceiver.cs
@@ -20,7 +20,13 @@ internal class SingletonChannelReceiver : IChannelReceiver
     internal TimeSpan TimerInterval { get; set; } = TimeSpan.FromMinutes(1);
     internal TimeSpan LockDuration { get; set; } = TimeSpan.FromMinutes(1);
     internal TimeSpan LockRefreshInterval { get; set; } = TimeSpan.FromSeconds(19);
-    private bool _lockPollingEnabled = false;
+
+    //Written by the lock-lost watcher thread and read by the timer loop
+    private volatile bool _lockPollingEnabled = false;
+
+    //Incremented for every successful lock acquisition, so a stale watcher from a previous
+    //acquisition cannot re-enable polling after the lock has already been re-acquired
+    private int _acquisitionGeneration;
     private Task _pollingLoop;
 
     /// <summary>
@@ -85,6 +91,7 @@ internal class SingletonChannelReceiver : IChannelReceiver
                 cancellationToken,
                 scopeTokenSource.Token
             );
+            var generation = Interlocked.Increment(ref _acquisitionGeneration);
             _singletonScope = new SingletonTimerScope(
                 _log,
                 lockHandle,
@@ -101,8 +108,12 @@ internal class SingletonChannelReceiver : IChannelReceiver
                     () =>
                     {
                         scopeTokenSource.Token.WaitHandle.WaitOne();
-                        //Stop signal received, restart the polling
-                        if (!cancellationToken.IsCancellationRequested)
+                        //Stop signal received, restart the polling. A watcher that wakes late,
+                        //after the lock has already been re-acquired, must not restart it
+                        if (
+                            !cancellationToken.IsCancellationRequested
+                            && Volatile.Read(ref _acquisitionGeneration) == generation
+                        )
                         {
                             _lockPollingEnabled = true;
                             _log.LogInformation(
@@ -133,7 +144,10 @@ internal class SingletonChannelReceiver : IChannelReceiver
         await AcquireLock(cancellationToken).ConfigureAwait(false);
 
 #pragma warning disable 4014
-        _pollingLoop = Task.Run(async () => await TimerLoop(cancellationToken), cancellationToken);
+        _pollingLoop = Task.Run(
+            async () => await TimerLoop(cancellationToken),
+            CancellationToken.None
+        );
 #pragma warning restore 4014
     }
 }

--- a/knightbus/tests/KnightBus.Host.Tests.Unit/SingletonChannelReceiverTests.cs
+++ b/knightbus/tests/KnightBus.Host.Tests.Unit/SingletonChannelReceiverTests.cs
@@ -89,11 +89,15 @@ public class SingletonChannelReceiverTests
             )
             .ReturnsAsync(handle.Object);
 
+        //The second renewal loses the lock, every other renewal succeeds
+        var renewCount = 0;
         handle
-            .SetupSequence(x => x.RenewAsync(It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true)
-            .Throws(new Exception())
-            .ReturnsAsync(true);
+            .Setup(x => x.RenewAsync(It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+            .Returns(() =>
+                Interlocked.Increment(ref renewCount) == 2
+                    ? throw new Exception("lock lost")
+                    : Task.FromResult(true)
+            );
 
         var underlyingReceiver = new Mock<IChannelReceiver>();
         underlyingReceiver.Setup(x => x.Settings).Returns(new Mock<IProcessingSettings>().Object);
@@ -103,13 +107,27 @@ public class SingletonChannelReceiverTests
             Mock.Of<ILogger>()
         )
         {
-            TimerInterval = TimeSpan.FromSeconds(1),
-            LockRefreshInterval = TimeSpan.FromSeconds(1),
+            TimerInterval = TimeSpan.FromMilliseconds(100),
+            LockRefreshInterval = TimeSpan.FromMilliseconds(100),
         };
         //act
         await singletonChannelReceiver.StartAsync(CancellationToken.None);
-        await Task.Delay(2100);
-        //assert
+
+        //assert: wait for the restart instead of a fixed delay
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (
+            underlyingReceiver.Invocations.Count(i =>
+                i.Method.Name == nameof(IChannelReceiver.StartAsync)
+            ) < 2
+            && DateTime.UtcNow < deadline
+        )
+        {
+            await Task.Delay(10, CancellationToken.None);
+        }
+
+        //let several timer intervals pass, a stale watcher would trigger a spurious
+        //third start in this window
+        await Task.Delay(500, CancellationToken.None);
         underlyingReceiver.Verify(
             x => x.StartAsync(It.IsAny<CancellationToken>()),
             Times.Exactly(2)


### PR DESCRIPTION
## Problem

Two defects around `SingletonChannelReceiver._lockPollingEnabled`, from the core review:

1. **No memory fence** — a plain `bool` written by the lock-lost watcher thread and read by the timer loop. Works in practice through async-machinery side effects, but the memory model doesn't guarantee the loop ever observes the write.
2. **Stale watcher re-enable** — a watcher from a previous acquisition can wake late (scheduler distortion, contended runners) and set the flag *after* the lock has already been re-acquired, making the timer loop attempt a spurious extra acquisition and `StartAsync` on the wrapped receiver. This is the race behind the `Should_restart_queue_reader_when_lock_is_lost` flake that produced a red master build (expected 2 starts, observed 3). In production a real lock manager returns null for a lease this instance already holds, so the impact there is wasteful re-polling rather than a correctness break — but the receiver restart path is mock-observable and CI-flaky.

## Fix

- `_lockPollingEnabled` is now `volatile`.
- Every successful acquisition increments an acquisition generation; the watcher only re-enables polling when its generation is still current, so only the *latest* acquisition's watcher can trigger a restart. A stale watcher becomes a no-op by construction.
- The polling loop's `Task.Run` no longer passes the cancellation token as a scheduling token (the same skip-the-delegate pattern removed everywhere else on this codebase).

## Test hardening — with a genuine find

`Should_restart_queue_reader_when_lock_is_lost` now waits for the restart event instead of a fixed 2100 ms delay, runs at 100 ms intervals, and asserts through a 500 ms settle window that no spurious third start occurs — the exact window where the stale-watcher bug would land.

Tightening the intervals exposed that the test's **mock** was the deeper source of flakiness: `SetupSequence(true, throw, true)` covers exactly three renewal calls, and every renewal after the sequence's end breaks — so given enough time the receiver *legitimately* loses the lock over and over (observed: 6 starts in 700 ms). The old fixed window simply ended before restart #3 arrived, making the assertion timing-dependent by construction. The mock now fails exactly one renewal and genuinely recovers.

Fixture stable across 8 consecutive runs; Host 50/50.

## Versions

- KnightBus.Host **18.1.1**

🤖 Generated with [Claude Code](https://claude.com/claude-code)