### PR TITLE
docs: stop implying middleware belongs to the transport it ships beside

### DIFF
--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -138,13 +138,28 @@ services.AddMiddleware<MyScopeProvider>();
 | `DeadLetterMiddleware` | always | Dead-letters once delivery attempts are exhausted, via the [`IProcessBeforeDeadLetter<T>`](../features/error-handling.md#hooking-into-dead-lettering) hook. |
 | Scope provider | always | One DI scope per message. |
 | `AttachmentMiddleware` | `UseBlobStorageAttachments()`, `UseRedisAttachments()` | Loads and cleans up [attachments](../features/attachments.md). |
-| `SagaMiddleware` | `EnableSagas(...)` | Loads and persists [saga](../features/sagas.md) state. |
+| `SagaMiddleware` | `EnableSagas(...)`, `UseBlobStorageSagas()`, `UsePostgresSagaStore()`, `UseRedisSagaStore()`, `UseSqlServerSagaStore(...)` | Loads and persists [saga](../features/sagas.md) state. |
 | `DistributedTracingMiddleware` | `UseDistributedTracing()` | Restores the incoming trace id into the message scope. |
 | `ThrottlingMiddleware` | `ThrottleHost(n)` | Host-wide concurrency gate. |
-| `ExtendMessageLockDurationMiddleware` | **manual** `AddMiddleware<...>()` | Renews the transport lock for [long-running work](processors.md#long-running-work-extending-the-lock). |
+| `ExtendMessageLockDurationMiddleware` | **manual** `AddMiddleware<...>()` | Renews the transport lock for [long-running work](processors.md#long-running-work-extending-the-lock), on transports that can renew one. |
 | `OpenTelemetryMessageMiddleware` | `UseOpenTelemetry()` | Emits spans — see [monitoring](../monitoring.md). |
 | `ApplicationInsightsMessageMiddleware` | `UseApplicationInsights(...)` | Application Insights telemetry. |
 | `NewRelicMessageMiddleware` | `UseNewRelic()` | New Relic transactions. |
+
+!!! note "A `Use…` call names a store, not a transport"
+    Every middleware above ships in `KnightBus.Core` or a monitoring package — **no transport package
+    contains one**. `UseRedisAttachments()` registers the Redis-backed attachment store and the core
+    `AttachmentMiddleware`; it does not make attachments a Redis feature, and it does not require the
+    Redis transport. The same goes for the saga stores and the Blob lock manager. Middleware is
+    registered per host and runs on **every** listener, whatever transport the message arrived on, so
+    attachments over NATS backed by Blob Storage — or any other combination — need no special
+    handling.
+
+    Two of them do depend on the transport for their *effect*, not their registration:
+    `AttachmentMiddleware` has nothing to load unless the sending bus ran the upload pre-processor
+    (all transports but PostgreSQL do), and `ExtendMessageLockDurationMiddleware` only renews a lock
+    when the message state handler implements `IMessageLockHandler<T>` (today only Storage Queues).
+    See the [transport matrix](../transports/index.md#feature-matrix).
 
 ## See also
 

--- a/docs/concepts/processors.md
+++ b/docs/concepts/processors.md
@@ -171,15 +171,18 @@ renewed every `ExtensionInterval` while your handler runs, and `MessageLockTimeo
 budget after which the handler's token is cancelled. The benefit is that a crashed host releases the
 message after `ExtensionDuration` instead of after the full two hours.
 
-!!! warning "Lock extension needs a middleware, and only works on Azure Storage Queues"
+!!! warning "Lock extension needs a middleware, and today renews only on Azure Storage Queues"
     Implementing the interface is not enough. You must register the middleware yourself:
 
     ```csharp
     services.AddMiddleware<ExtendMessageLockDurationMiddleware>();
     ```
 
-    Renewal also requires the transport to support changing a lock mid-flight, which today only
-    Azure Storage Queues does. See
+    `ExtendMessageLockDurationMiddleware` is a `KnightBus.Core` middleware like any other: it is
+    registered per host, not per transport, and runs on every listener. What it cannot do is renew a
+    lock the transport will not let it renew — the message state handler has to implement
+    `IMessageLockHandler<T>`, which today only Azure Storage Queues does. On other transports the
+    middleware simply passes the message through. See
     [errors and dead-lettering](../features/error-handling.md#message-locks).
 
 !!! danger "Do not use `IExtendMessageLockTimeout` on the PostgreSQL transport"

--- a/docs/features/attachments.md
+++ b/docs/features/attachments.md
@@ -103,9 +103,13 @@ uploads, the receiver downloads.
 
     There is no options overload; Redis attachments are stored uncompressed.
 
-Blob Storage is the usual choice even when the messages travel over another transport — the NATS
-example uses NATS for messages and Blob Storage for attachments. The provider is chosen per host, not
-per transport.
+Either provider works with any transport. Blob Storage is the usual choice even when the messages
+travel over another transport — the NATS example uses NATS for messages and Blob Storage for
+attachments — and `UseRedisAttachments()` is equally available to an application with no Redis
+transport. Both calls register the same core `AttachmentMiddleware`; what differs is only where the
+bytes land. The provider is chosen per host, not per transport, and the middleware resolves a single
+`IMessageAttachmentProvider` — so register one, since a second registration silently wins over the
+first.
 
 ## Lifecycle and cleanup
 

--- a/docs/features/error-handling.md
+++ b/docs/features/error-handling.md
@@ -88,8 +88,9 @@ processing, and the reason to honour the cancellation token.
 
 For genuinely long work, prefer a short renewed lock over one enormous timeout — see
 [extending the lock](../concepts/processors.md#long-running-work-extending-the-lock). That mechanism
-needs `ExtendMessageLockDurationMiddleware` registered manually and only functions on Azure Storage
-Queues, the sole transport that can change a lock mid-flight.
+needs `ExtendMessageLockDurationMiddleware` registered manually. The middleware is a core one and may
+be registered on any host, but it can only renew where the transport can change a lock mid-flight,
+which today is Azure Storage Queues alone.
 
 ## Where dead letters go
 

--- a/docs/features/sagas.md
+++ b/docs/features/sagas.md
@@ -10,7 +10,8 @@ state table and concurrency control.
 
 ## Enabling sagas
 
-Register a saga store. Each transport that has one ships a registration extension:
+Register a saga store. Four packages ship one, each with its own registration extension. The package
+a store ships in does not tie it to that transport — pick whichever store suits the workload:
 
 === "Azure Blob Storage"
 

--- a/docs/reference/marker-interfaces.md
+++ b/docs/reference/marker-interfaces.md
@@ -240,6 +240,11 @@ searching for an interface to make one of these happen, there isn't one:
 | Telemetry | `UseOpenTelemetry()` / `UseApplicationInsights(...)` / `UseNewRelic()` |
 | Queue management | `AddServiceBusManagement(...)` and friends |
 
+Where a row lists several calls, they are alternative *stores*, not one call per transport:
+`UseRedisAttachments()` and `UsePostgresSagaStore()` are as valid in a Service Bus application as
+anywhere else. Only queue management is transport-specific. See the
+[transport matrix](../transports/index.md#feature-matrix).
+
 ## Quick diagnosis
 
 | Symptom | Likely cause |

--- a/docs/transports/azure-service-bus.md
+++ b/docs/transports/azure-service-bus.md
@@ -172,7 +172,9 @@ delivery) and `CancelScheduledMessage` through the management API.
 ## Attachments
 
 Service Bus messages are size-limited, so large payloads belong in
-[attachments](../features/attachments.md), typically backed by Blob Storage:
+[attachments](../features/attachments.md). This package ships no attachment provider, which is not a
+gap — the provider is a host-wide choice, and either of the two that exist can back attachments here.
+Blob Storage is the usual pick:
 
 ```csharp
 services
@@ -181,6 +183,11 @@ services
     .UseBlobStorageAttachments()
     .UseTransport<ServiceBusTransport>();
 ```
+
+Note that only `UseTransport<ServiceBusTransport>()` appears — `UseBlobStorage(...)` supplies the
+storage account for the attachments and does not start any Storage Queues listener. The same pattern
+gives Service Bus messages [sagas](../features/sagas.md) and
+[singleton processing](../features/singleton-processing.md), which likewise ship in other packages.
 
 ## Serialization
 

--- a/docs/transports/azure-storage-queues.md
+++ b/docs/transports/azure-storage-queues.md
@@ -1,8 +1,10 @@
 # Azure Storage Queues
 
 Cheap, durable and simple. Commands only — no pub/sub — but it is the transport with the best support
-for long-running work, and the package also supplies the attachment provider, saga store and
-singleton lock manager that other transports borrow.
+for long-running work, and the package supplies the attachment provider, saga store and singleton
+lock manager that the rest of KnightBus builds on. Those three are host-wide features and work with
+any transport; they need `UseBlobStorage(...)` for the storage account, not
+`UseTransport<StorageTransport>()`.
 
 ```bash
 dotnet add package KnightBus.Azure.Storage
@@ -104,6 +106,13 @@ The benefit over one enormous `MessageLockTimeout` is recovery time: if the host
 becomes visible again after `ExtensionDuration` rather than after the full four hours. See
 [extending the lock](../concepts/processors.md#long-running-work-extending-the-lock).
 
+The middleware itself is a `KnightBus.Core` type rather than a Storage Queues one: it is registered
+per host and runs on every listener. What it cannot do elsewhere is *renew* — that needs the message
+state handler to implement `IMessageLockHandler<T>`, which today is this transport alone. On other
+transports it passes messages through untouched, with one exception: on PostgreSQL, implementing
+`IExtendMessageLockTimeout` shortens the fetch lock with nothing able to renew it, which causes
+duplicate processing.
+
 ## Attachments
 
 The Blob Storage attachment provider is the one most applications use, whatever transport carries the
@@ -136,8 +145,9 @@ services.UseBlobStorageSagas();
 ```
 
 State is stored in the `knightbus-sagas` container with the blob ETag providing optimistic
-concurrency. Expiry is evaluated on read, so expired blobs are reported as not found but are not
-deleted for you. See [sagas](../features/sagas.md).
+concurrency — the only shipped store that detects concurrent writes, which is reason enough to choose
+it whatever transport carries the saga's messages. Expiry is evaluated on read, so expired blobs are
+reported as not found but are not deleted for you. See [sagas](../features/sagas.md).
 
 ## Singleton lock manager
 

--- a/docs/transports/index.md
+++ b/docs/transports/index.md
@@ -18,6 +18,8 @@ with no routing configuration anywhere.
 
 ## Feature matrix
 
+What the transport itself can do:
+
 | | [Service Bus](azure-service-bus.md) | [Storage Queues](azure-storage-queues.md) | [PostgreSQL](postgresql.md) | [Redis](redis.md) | [NATS](nats.md) |
 | --- | :--: | :--: | :--: | :--: | :--: |
 | Commands | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -26,30 +28,57 @@ with no routing configuration anywhere.
 | Streaming responses | — | — | — | — | ✅ |
 | Deferred delivery | ✅ | ✅ | ✅ | — | — |
 | Cancel deferred message | ✅ | — | — | — | — |
-| Attachments | ✅ | ✅ | — | ✅ | ✅ |
-| Saga store | — | ✅ | ✅ | ✅ | — |
-| Singleton lock manager | — | ✅ | — | — | — |
 | Dead letter queue | ✅ | ✅ | ✅ | ✅ | — |
 | Management API | ✅ | ✅ | ✅ | ✅ | — |
 | Message lock extension | — | ✅ | — | — | — |
+| Carries attachments | ✅ | ✅ | — | ✅ | ✅ |
 | Default serializer | Newtonsoft | Newtonsoft | System.Text.Json | Newtonsoft | Newtonsoft |
 
-Two rows need explanation, and they mean different things.
+What each package *ships* — a different question, answered by a different table:
 
-**Attachments** ✅ means "attachments work on this transport", not "this package provides the
-storage". Only two packages ship an `IMessageAttachmentProvider` — `KnightBus.Azure.Storage` (Blob,
-the usual choice) and `KnightBus.Redis` — and either can back attachments on any transport. So a
-message travelling over NATS with its payload in Blob Storage is a normal arrangement. The PostgreSQL
-✗ is genuine, though: that transport does not run the pre-processor that uploads attachments, so they
-never get stored.
+| | Service Bus | Storage Queues | PostgreSQL | Redis | NATS | [SQL Server](../features/sagas.md) |
+| --- | :--: | :--: | :--: | :--: | :--: | :--: |
+| Attachment provider | — | ✅ Blob | — | ✅ | — | — |
+| Saga store | — | ✅ Blob | ✅ | ✅ | — | ✅ |
+| Singleton lock manager | — | ✅ Blob lease | — | — | — | — |
 
-**Saga store** ✅ means the package ships an `ISagaStore` implementation. Saga state is likewise
-independent of the transport carrying the messages — see [sagas](../features/sagas.md) for the
-important differences between the stores, particularly that only the Blob store detects concurrent
-writes.
+### The second table is not a restriction
 
-**SQL Server** appears nowhere above because `KnightBus.SqlServer` is a
-[saga store](../features/sagas.md) only, not a transport.
+Nothing in the second table belongs to the transport it ships beside. Attachments, sagas and
+singleton locks are host-wide features whose middleware lives in `KnightBus.Core`, and they are
+configured **once per host, not per transport**. A `UseXxxAttachments()` or `UseXxxSagaStore()` call
+names the *storage* backing the feature; it says nothing about which transport your messages travel
+over. `KnightBus.SqlServer` is the case that makes this obvious — a saga store with no transport at
+all.
+
+So all of these are ordinary arrangements, not workarounds:
+
+- messages over NATS, attachments in Blob Storage, saga state in PostgreSQL;
+- messages over Service Bus with singleton processors, coordinated by Blob leases — the only lock
+  implementation KnightBus ships, and the reason `KnightBus.Azure.Storage` appears in applications
+  that use no Azure queue at all;
+- messages over Redis with attachments in Blob Storage, because Redis keeps its own in memory.
+
+Pick each row of the second table on its own merits — cost, durability, what you already operate —
+and mix freely. The differences that matter are between the *implementations*, not the transports:
+see [sagas](../features/sagas.md#concurrency) for the important one, that only the Blob store detects
+concurrent writes.
+
+### Where the transport does constrain you
+
+Two rows in the first table are the real couplings, and they fail in opposite directions.
+
+**Carries attachments** is about the send side. An attachment is uploaded by an
+[`IMessagePreProcessor`](../concepts/messages.md#pre-processing-messages-on-send), and `PostgresBus`
+does not run pre-processors — so a message sent over PostgreSQL never gets its attachment stored,
+whichever provider is registered. Every other transport carries attachments from either provider.
+
+**Message lock extension** is about the receive side. `ExtendMessageLockDurationMiddleware` is a core
+middleware you may register on any host, but it can only renew a lock the transport lets it renew:
+the message state handler has to implement `IMessageLockHandler<T>`, which today only Storage Queues
+does. Elsewhere the middleware is inert — and on PostgreSQL, implementing `IExtendMessageLockTimeout`
+is worse than inert, see
+[extending the lock](../concepts/processors.md#long-running-work-extending-the-lock).
 
 ## Choosing one
 

--- a/docs/transports/postgresql.md
+++ b/docs/transports/postgresql.md
@@ -121,7 +121,10 @@ does not collide with your application's own data source registration.
 services.UsePostgresSagaStore();
 ```
 
-State goes in `knightbus.sagas`, created on demand.
+State goes in `knightbus.sagas`, created on demand. The store is independent of the transport — it
+holds [saga](../features/sagas.md) state for messages arriving on any transport, and needs
+`UsePostgres(...)` for the connection rather than `UseTransport<PostgresTransport>()`. Conversely,
+sagas whose messages travel over PostgreSQL can use any other store.
 
 !!! warning "No concurrent-write detection"
     This store overwrites unconditionally — it does not check `ConcurrencyStamp`, so simultaneous

--- a/docs/transports/redis.md
+++ b/docs/transports/redis.md
@@ -1,7 +1,9 @@
 # Redis
 
-The highest-throughput KnightBus transport. Commands, events and attachments, with a saga store, built
-on Redis lists.
+The highest-throughput KnightBus transport: commands and events built on Redis lists. The package
+also ships an attachment provider and a saga store, which are host-wide features rather than Redis
+transport features — any transport can use them, and this transport can equally use the ones shipped
+by other packages.
 
 ```bash
 dotnet add package KnightBus.Redis
@@ -86,10 +88,14 @@ services
     .UseRedisAttachments();
 ```
 
-Attachments are stored in Redis itself, uncompressed — there is no options overload. For large or
-long-lived attachments, prefer the
-[Blob Storage provider](azure-storage-queues.md#attachments) even on this transport, since Redis keeps
-everything in memory.
+Attachments are stored in Redis itself, uncompressed — there is no options overload.
+
+This registers a *provider*, not a Redis-transport feature. `UseRedisAttachments()` backs
+[attachments](../features/attachments.md) for every transport in the host — a Service Bus or NATS
+message can carry its payload in Redis — and it needs `UseRedis(...)` for the connection, not
+`UseTransport<RedisTransport>()`. The reverse holds too: messages travelling over Redis can use the
+[Blob Storage provider](azure-storage-queues.md#attachments) instead, which is the better choice for
+large or long-lived attachments since Redis keeps everything in memory.
 
 ## Saga store
 
@@ -97,7 +103,9 @@ everything in memory.
 services.UseRedisSagaStore();
 ```
 
-State is stored under `sagas:{partitionKey}:{id}`.
+State is stored under `sagas:{partitionKey}:{id}`. Like the attachment provider, this is independent
+of the transport: it stores [saga](../features/sagas.md) state for messages arriving on any
+transport, and sagas over Redis can just as well use the Blob, PostgreSQL or SQL Server store.
 
 !!! warning "No concurrent-write detection, and updated sagas never expire"
     Two independent problems with this store:


### PR DESCRIPTION
The transport pages presented attachments, saga stores and the singleton lock manager as capabilities of the transport whose package ships them. They are host-wide features: every `IMessageProcessorMiddleware` lives in `KnightBus.Core` (or a monitoring package), the transport packages only add a provider or store alongside it, and a `UseXxxAttachments()` / `UseXxxSagaStore()` call names the *storage* rather than the transport. Those calls need `UseRedis(...)` / `UseBlobStorage(...)` for the connection, never `UseTransport<...>()`.

## Changes

- **`docs/transports/index.md`** — split the single feature matrix into two: what the transport itself can do, and what each package ships (attachment provider / saga store / lock manager, now including SQL Server). Added a section stating that the second table is a menu rather than a restriction, with worked combinations.
- **The two couplings that are real**, documented separately because they fail in opposite directions:
  - *Send side* — attachments upload via an `IMessagePreProcessor`, and `PostgresBus` does not run pre-processors, so a message sent over PostgreSQL never gets its attachment stored whatever provider is registered.
  - *Receive side* — `ExtendMessageLockDurationMiddleware` may be registered on any host but only renews where the message state handler implements `IMessageLockHandler<T>`; today only `StorageQueueMessageStateHandler` does. Elsewhere it is inert, except on PostgreSQL where the existing "actively harmful" warning still applies.
- **Same conflation corrected** on the Redis, Storage Queues, Service Bus and PostgreSQL pages, in `concepts/middleware.md`, `features/attachments.md`, `features/sagas.md`, `concepts/processors.md`, `features/error-handling.md`, and `reference/marker-interfaces.md`.

## Verification

Claims checked against the source rather than the existing prose — `StorageExtensions.cs`, `RedisExtensions.cs`, `SagaExtensions.cs`, `ExtendMessageLockDurationMiddleware.cs`, and the store constructors' DI dependencies. `mkdocs build --strict` (the CI gate) passes locally with the pinned toolchain, so the new cross-page anchors all resolve.

Docs only — no code or behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8YZoc2CJnvdCynL6ejAZv