### PR TITLE
feat: run message pre-processors on the PostgreSQL transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+# 2026-08-25
+
+### KnightBus.PostgreSql 4.0.0
+* PostgresBus now runs message pre-processors on send, schedule and publish, storing the returned properties in the `properties` column. Attachments and outgoing distributed tracing now work on this transport
+* `publish_events` gained a three-argument overload carrying properties; the two-argument overload is kept for older publishers. A publisher that finds the new overload missing creates it and retries, which requires DDL rights on the knightbus schema — roles without them can create it up front via `QueueInitializer.InitPublishFunction`
+* Breaking: the PostgresBus constructor takes `IEnumerable<IMessagePreProcessor>`. No change needed when resolving `IPostgresBus` through DI
+* Fixed: ScheduleAsync with a fractional-second delay no longer fails under comma-decimal cultures for batches under 50 messages; the delay is now a typed interval parameter
+
 # 2026-08-24
 
 ### KnightBus.Azure.Storage 18.1.0

--- a/docs/concepts/messages.md
+++ b/docs/concepts/messages.md
@@ -171,13 +171,8 @@ services.AddScoped<IMessagePreProcessor, TenantPreProcessor>();
 ```
 
 Every registered pre-processor runs for every outgoing message, and the resulting properties are
-merged onto the transport message (Service Bus application properties, NATS headers, and so on).
-
-!!! warning "Pre-processors do not run on the PostgreSQL transport"
-    `PostgresBus` does not resolve `IMessagePreProcessor` at all. Anything built on pre-processing —
-    [attachments](../features/attachments.md) and outgoing
-    [distributed tracing](../monitoring.md#distributed-tracing) — therefore has no effect when
-    sending over PostgreSQL.
+merged onto the transport message (Service Bus application properties, NATS headers, the PostgreSQL
+`properties` column, and so on).
 
 ## See also
 

--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -155,10 +155,9 @@ services.AddMiddleware<MyScopeProvider>();
     attachments over NATS backed by Blob Storage — or any other combination — need no special
     handling.
 
-    Two of them do depend on the transport for their *effect*, not their registration:
-    `AttachmentMiddleware` has nothing to load unless the sending bus ran the upload pre-processor
-    (all transports but PostgreSQL do), and `ExtendMessageLockDurationMiddleware` only renews a lock
-    when the message state handler implements `IMessageLockHandler<T>` (today only Storage Queues).
+    One of them does depend on the transport for its *effect*, not its registration:
+    `ExtendMessageLockDurationMiddleware` only renews a lock when the message state handler
+    implements `IMessageLockHandler<T>` (today only Storage Queues).
     See the [transport matrix](../transports/index.md#feature-matrix).
 
 ## See also

--- a/docs/features/attachments.md
+++ b/docs/features/attachments.md
@@ -4,8 +4,8 @@ Attachments let a message carry a payload far larger than the transport allows. 
 out of band and only its id travels in the message body, so a 100 MB file can ride on a transport
 with a 256 KB message limit.
 
-Attachments are transport independent: the same mechanism works on Service Bus, Storage Queues, Redis
-and NATS.
+Attachments are transport independent: the same mechanism works on Service Bus, Storage Queues,
+PostgreSQL, Redis and NATS.
 
 ## Sending an attachment
 
@@ -142,13 +142,9 @@ On send, an `IMessagePreProcessor` uploads the attachment and puts its id in the
 message property. On receive, `AttachmentMiddleware` reads that property, downloads the file and
 assigns `message.Attachment` before your processor runs.
 
-Two consequences follow:
-
-- **Serializers must skip the `Attachment` property.** Both bundled serializers do. If you write your
-  own, mirror that — see [serialization](../concepts/serialization.md#writing-your-own).
-- **Attachments do not work on the PostgreSQL transport.** `PostgresBus` does not run pre-processors,
-  so nothing uploads the attachment. Use another transport for messages with attachments, or store
-  the payload yourself and send a reference.
+One consequence follows: **serializers must skip the `Attachment` property.** Both bundled
+serializers do. If you write your own, mirror that — see
+[serialization](../concepts/serialization.md#writing-your-own).
 
 ## Custom providers
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -128,10 +128,6 @@ public class SampleProcessor : IProcessCommand<SampleCommand, DefaultSettings>
 To integrate with a different correlation scheme, implement `IDistributedTracingProvider` and
 register it with `UseDistributedTracing<MyProvider>()`.
 
-!!! warning "Not propagated by the PostgreSQL transport"
-    Outgoing trace properties are attached by a pre-processor, and `PostgresBus` does not run
-    pre-processors — so trace context is not propagated when sending over PostgreSQL.
-
 ## Liveness probes
 
 `UseTcpAliveListener(port)` opens a TCP port for orchestrator health checks. It stops answering as

--- a/docs/reference/marker-interfaces.md
+++ b/docs/reference/marker-interfaces.md
@@ -30,7 +30,7 @@ in KnightBus.
 | `ICommand` | One logical consumer. | Implement a transport-specific descendant instead. |
 | `IEvent` | Fan-out to many subscriptions. | Implement a transport-specific descendant instead. |
 | `IRequest` | Request/response. | Implement `INatsRequest`; only NATS supports requests. |
-| `ICommandWithAttachment` | Adds an out-of-band payload. | Requires a registered attachment provider on **both** sender and receiver. Adds `IMessageAttachment Attachment { get; set; }`. Not supported when sending over PostgreSQL. |
+| `ICommandWithAttachment` | Adds an out-of-band payload. | Requires a registered attachment provider on **both** sender and receiver. Adds `IMessageAttachment Attachment { get; set; }`. |
 
 ### Transport interfaces
 
@@ -254,7 +254,7 @@ anywhere else. Only queue management is transport-specific. See the
 | `No queue name mapping exists for {type}` | Mapping missing, or not in the same assembly as the message. |
 | Host fails: no `ISingletonLockManager` | `ISingletonProcessor` or `UseScheduling()` without a lock manager. |
 | Lock extension has no effect | Middleware not registered, or transport is not Azure Storage Queues. |
-| Attachment is null on receive | No attachment provider on the receiving host, or the message was sent over PostgreSQL. |
+| Attachment is null on receive | No attachment provider on the receiving host. |
 | Dead letter hook never fires | Transport's own delivery limit is lower than `DeadLetterDeliveryLimit`. |
 | Custom serializer ignored | Placed on the message or processor instead of the mapping — or sending over PostgreSQL. |
 | `An instance of ISagaStore is already registered` | Two saga stores registered; only one is allowed. |

--- a/docs/transports/index.md
+++ b/docs/transports/index.md
@@ -31,7 +31,7 @@ What the transport itself can do:
 | Dead letter queue | ✅ | ✅ | ✅ | ✅ | — |
 | Management API | ✅ | ✅ | ✅ | ✅ | — |
 | Message lock extension | — | ✅ | — | — | — |
-| Carries attachments | ✅ | ✅ | — | ✅ | ✅ |
+| Carries attachments | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Default serializer | Newtonsoft | Newtonsoft | System.Text.Json | Newtonsoft | Newtonsoft |
 
 What each package *ships* — a different question, answered by a different table:
@@ -66,12 +66,7 @@ concurrent writes.
 
 ### Where the transport does constrain you
 
-Two rows in the first table are the real couplings, and they fail in opposite directions.
-
-**Carries attachments** is about the send side. An attachment is uploaded by an
-[`IMessagePreProcessor`](../concepts/messages.md#pre-processing-messages-on-send), and `PostgresBus`
-does not run pre-processors — so a message sent over PostgreSQL never gets its attachment stored,
-whichever provider is registered. Every other transport carries attachments from either provider.
+One row in the first table is a real coupling.
 
 **Message lock extension** is about the receive side. `ExtendMessageLockDurationMiddleware` is a core
 middleware you may register on any host, but it can only renew a lock the transport lets it renew:

--- a/docs/transports/postgresql.md
+++ b/docs/transports/postgresql.md
@@ -112,6 +112,20 @@ Publishing an event calls the `publish_events` function, which inserts the messa
 subscription's table. So an event with three subscriptions is stored three times, and each subscriber
 consumes independently.
 
+The function exists in two overloads: a three-argument one that also carries
+[pre-processor](../concepts/messages.md#pre-processing-messages-on-send) properties, and a legacy
+two-argument one kept for publishers on `KnightBus.PostgreSql` versions before 4.0.0. Both are
+created whenever a listener initializes a subscription, and a 4.0.0 publisher that finds the
+three-argument overload missing — a database initialized by an older version — creates it and
+retries the publish.
+
+!!! warning "Publishers may need DDL rights when upgrading to 4.0.0"
+    Listeners only run initialization when a subscription table is missing, so on an existing
+    database it is the publisher that creates the new overload on its first publish. That requires
+    its database role to be allowed to create functions in the `knightbus` schema. If the role has
+    no DDL rights, create the overload during the upgrade instead —
+    `QueueInitializer.InitPublishFunction` emits it.
+
 The connection is registered as a keyed `NpgsqlDataSource` under the key `knightbus-postgres`, so it
 does not collide with your application's own data source registration.
 
@@ -134,17 +148,7 @@ sagas whose messages travel over PostgreSQL can use any other store.
 
 ## Limitations
 
-Two behaviours specific to this transport are worth knowing before you choose it:
-
-!!! warning "No attachments, no outgoing trace propagation"
-    `PostgresBus` does not run [message pre-processors](../concepts/messages.md#pre-processing-messages-on-send).
-    Anything built on them has no effect when sending over PostgreSQL:
-
-    - **[Attachments](../features/attachments.md)** are never uploaded.
-    - **Outgoing [distributed tracing](../monitoring.md#distributed-tracing)** properties are not
-      attached.
-
-    Custom pre-processors you register are also skipped for these messages.
+One behaviour specific to this transport is worth knowing before you choose it:
 
 !!! warning "`ICustomMessageSerializer` is ignored when sending"
     The serializer is captured when the client is constructed, so a per-message override on the

--- a/knightbus-postgresql/src/KnightBus.PostgreSql/KnightBus.PostgreSql.csproj
+++ b/knightbus-postgresql/src/KnightBus.PostgreSql/KnightBus.PostgreSql.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>PostgreSQL Transport for KnightBus</Description>
-    <Version>3.0.1$(VersionSuffix)</Version>
+    <Version>4.0.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/knightbus-postgresql/src/KnightBus.PostgreSql/PostgresBus.cs
+++ b/knightbus-postgresql/src/KnightBus.PostgreSql/PostgresBus.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data;
 using KnightBus.Core;
+using KnightBus.Core.PreProcessors;
 using KnightBus.Messages;
 using KnightBus.PostgreSql.Messages;
 using Microsoft.Extensions.DependencyInjection;
@@ -29,14 +30,17 @@ public class PostgresBus : IPostgresBus
 {
     private readonly NpgsqlDataSource _npgsqlDataSource;
     private readonly IMessageSerializer _serializer;
+    private readonly IEnumerable<IMessagePreProcessor> _messagePreProcessors;
 
     public PostgresBus(
         [FromKeyedServices(NpgsqlDataSourceContainerKey)] NpgsqlDataSource npgsqlDataSource,
-        IPostgresConfiguration postgresConfiguration
+        IPostgresConfiguration postgresConfiguration,
+        IEnumerable<IMessagePreProcessor> messagePreProcessors
     )
     {
         _npgsqlDataSource = npgsqlDataSource;
         _serializer = postgresConfiguration.MessageSerializer;
+        _messagePreProcessors = messagePreProcessors;
     }
 
     public Task SendAsync<T>(T message, CancellationToken ct)
@@ -83,46 +87,49 @@ public class PostgresBus : IPostgresBus
         where T : IPostgresCommand
     {
         var queueName = AutoMessageMapper.GetQueueName<T>();
-        var messagesList = messages.ToList();
+        var rows = await SerializeMessagesAsync(messages, ct).ConfigureAwait(false);
 
         await using var connection = await _npgsqlDataSource
             .OpenConnectionAsync(ct)
             .ConfigureAwait(false);
 
-        if (messagesList.Count < 50)
+        if (rows.Count < 50)
         {
-            await BatchInsert(connection, queueName, messagesList, delay, ct).ConfigureAwait(false);
+            await BatchInsert(connection, queueName, rows, delay, ct).ConfigureAwait(false);
             return;
         }
 
-        await BatchCopy(connection, queueName, messagesList, delay, ct).ConfigureAwait(false);
+        await BatchCopy(connection, queueName, rows, delay, ct).ConfigureAwait(false);
     }
 
-    private async Task BatchInsert<T>(
+    private static async Task BatchInsert(
         NpgsqlConnection connection,
         string queueName,
-        List<T> messages,
+        List<(byte[] Message, byte[]? Properties)> rows,
         TimeSpan? delay,
         CancellationToken ct
     )
-        where T : IPostgresCommand
     {
-        var visibilityTimeout = $"now() + INTERVAL '{delay?.TotalSeconds ?? 0} seconds'";
-
         await using var batch = new NpgsqlBatch(connection);
-        foreach (var messageBody in messages.Select(message => _serializer.Serialize(message)))
+        foreach (var row in rows)
         {
             batch.BatchCommands.Add(
                 new NpgsqlBatchCommand(
                     //lang=postgresql
-                    $"INSERT INTO {SchemaName}.{QueuePrefix}_{queueName} (visibility_timeout, message) VALUES ({visibilityTimeout}, $1)"
+                    $"INSERT INTO {SchemaName}.{QueuePrefix}_{queueName} (visibility_timeout, message, properties) VALUES (now() + $1, $2, $3)"
                 )
                 {
                     Parameters =
                     {
+                        new NpgsqlParameter<TimeSpan> { TypedValue = delay ?? TimeSpan.Zero },
                         new NpgsqlParameter<byte[]>
                         {
-                            TypedValue = messageBody,
+                            TypedValue = row.Message,
+                            NpgsqlDbType = NpgsqlDbType.Jsonb,
+                        },
+                        new NpgsqlParameter
+                        {
+                            Value = (object?)row.Properties ?? DBNull.Value,
                             NpgsqlDbType = NpgsqlDbType.Jsonb,
                         },
                     },
@@ -134,31 +141,36 @@ public class PostgresBus : IPostgresBus
         await batch.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
-    private async Task BatchCopy<T>(
+    private static async Task BatchCopy(
         NpgsqlConnection connection,
         string queueName,
-        List<T> messages,
+        List<(byte[] Message, byte[]? Properties)> rows,
         TimeSpan? delay,
         CancellationToken ct
     )
-        where T : IPostgresCommand
     {
         string sql =
             //lang=postgresql
-            $"COPY {SchemaName}.{QueuePrefix}_{queueName} (visibility_timeout, message) FROM STDIN (FORMAT binary)";
+            $"COPY {SchemaName}.{QueuePrefix}_{queueName} (visibility_timeout, message, properties) FROM STDIN (FORMAT binary)";
 
         await using var importer = await connection
             .BeginBinaryImportAsync(sql, ct)
             .ConfigureAwait(false);
 
         var visibilityTimeout = DateTimeOffset.UtcNow.AddSeconds(delay?.TotalSeconds ?? 0);
-        foreach (var messageBody in messages.Select(message => _serializer.Serialize(message)))
+        foreach (var row in rows)
         {
             await importer.StartRowAsync(ct).ConfigureAwait(false);
             await importer
                 .WriteAsync(visibilityTimeout, NpgsqlDbType.TimestampTz, ct)
                 .ConfigureAwait(false);
-            await importer.WriteAsync(messageBody, NpgsqlDbType.Jsonb, ct).ConfigureAwait(false);
+            await importer.WriteAsync(row.Message, NpgsqlDbType.Jsonb, ct).ConfigureAwait(false);
+            if (row.Properties is null)
+                await importer.WriteNullAsync(ct).ConfigureAwait(false);
+            else
+                await importer
+                    .WriteAsync(row.Properties, NpgsqlDbType.Jsonb, ct)
+                    .ConfigureAwait(false);
         }
 
         await importer.CompleteAsync(ct).ConfigureAwait(false);
@@ -168,16 +180,46 @@ public class PostgresBus : IPostgresBus
         where T : IPostgresEvent
     {
         var topicName = AutoMessageMapper.GetQueueName<T>();
+        var rows = await SerializeMessagesAsync(messages, ct).ConfigureAwait(false);
+        var serialized = new byte[rows.Count][];
+        var properties = new byte[]?[rows.Count];
+        for (var i = 0; i < rows.Count; i++)
+        {
+            serialized[i] = rows[i].Message;
+            properties[i] = rows[i].Properties;
+        }
+
         await using var connection = await _npgsqlDataSource
             .OpenConnectionAsync(ct)
             .ConfigureAwait(false);
 
+        try
+        {
+            await ExecutePublish(connection, topicName, serialized, properties, ct)
+                .ConfigureAwait(false);
+        }
+        catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.UndefinedFunction)
+        {
+            // Databases initialized before 4.0.0 lack the properties overload, and consumers
+            // only run initialization when a subscription table is missing
+            await QueueInitializer.InitPublishFunction(connection).ConfigureAwait(false);
+            await ExecutePublish(connection, topicName, serialized, properties, ct)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static async Task ExecutePublish(
+        NpgsqlConnection connection,
+        string topicName,
+        byte[][] serialized,
+        byte[]?[] properties,
+        CancellationToken ct
+    )
+    {
         await using var cmd = new NpgsqlCommand(
-            $"select {SchemaName}.publish_events($1, $2)",
+            $"select {SchemaName}.publish_events($1, $2, $3)",
             connection
         );
-
-        var serialized = messages.Select(m => _serializer.Serialize(m)).ToArray();
 
         cmd.CommandType = CommandType.Text;
         cmd.Parameters.Add(
@@ -190,7 +232,53 @@ public class PostgresBus : IPostgresBus
                 NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Jsonb,
             }
         );
+        cmd.Parameters.Add(
+            new NpgsqlParameter
+            {
+                Value = properties,
+                NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Jsonb,
+            }
+        );
         await cmd.PrepareAsync(ct);
         await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    // Pre-processors can perform slow I/O such as attachment uploads, so all rows are
+    // serialized before a connection is opened or a COPY transaction is started
+    private async Task<List<(byte[] Message, byte[]? Properties)>> SerializeMessagesAsync<T>(
+        IEnumerable<T> messages,
+        CancellationToken ct
+    )
+        where T : IMessage
+    {
+        var rows = new List<(byte[], byte[]?)>();
+        foreach (var message in messages)
+        {
+            rows.Add(
+                (
+                    _serializer.Serialize(message),
+                    await SerializePropertiesAsync(message, ct).ConfigureAwait(false)
+                )
+            );
+        }
+
+        return rows;
+    }
+
+    private async Task<byte[]?> SerializePropertiesAsync<T>(T message, CancellationToken ct)
+        where T : IMessage
+    {
+        Dictionary<string, string>? properties = null;
+        foreach (var preProcessor in _messagePreProcessors)
+        {
+            var result = await preProcessor.PreProcess(message, ct).ConfigureAwait(false);
+            foreach (var property in result)
+            {
+                properties ??= new Dictionary<string, string>();
+                properties[property.Key] = property.Value.ToString() ?? string.Empty;
+            }
+        }
+
+        return properties is null ? null : _serializer.Serialize(properties);
     }
 }

--- a/knightbus-postgresql/src/KnightBus.PostgreSql/QueueInitializer.cs
+++ b/knightbus-postgresql/src/KnightBus.PostgreSql/QueueInitializer.cs
@@ -58,6 +58,12 @@ public static class QueueInitializer
         await transaction.CommitAsync();
     }
 
+    public static async Task InitPublishFunction(NpgsqlConnection connection)
+    {
+        await using var createPublishFunctionCmd = CreatePublishFunction(connection);
+        await createPublishFunctionCmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+
     public static async Task InitQueue(
         PostgresQueueName queueName,
         NpgsqlDataSource npgsqlDataSource
@@ -124,6 +130,7 @@ DO NOTHING;",
 
     private static NpgsqlCommand CreatePublishFunction(NpgsqlConnection connection)
     {
+        // The 2-arg overload is kept for publishers running versions without preprocessor support
         var publishFunction = new NpgsqlCommand(
             @$"
 CREATE OR REPLACE FUNCTION {SchemaName}.publish_events(
@@ -136,13 +143,35 @@ DECLARE
 BEGIN
     FOR subscription_name IN
         EXECUTE format('SELECT subscription_name FROM %I.t_%I', '{SchemaName}', topic)
-    LOOP      
+    LOOP
 
         -- Insert all messages into the queue table in a single statement
         EXECUTE format('
             INSERT INTO %I.s_%I_%I (visibility_timeout, message)
             SELECT now(), unnest($1)
         ', '{SchemaName}', topic, subscription_name) USING messages;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION {SchemaName}.publish_events(
+    topic TEXT,
+    messages JSONB[],
+    properties JSONB[]
+)
+RETURNS VOID AS $$
+DECLARE
+    subscription_name TEXT;
+BEGIN
+    FOR subscription_name IN
+        EXECUTE format('SELECT subscription_name FROM %I.t_%I', '{SchemaName}', topic)
+    LOOP
+
+        -- Insert all messages into the queue table in a single statement
+        EXECUTE format('
+            INSERT INTO %I.s_%I_%I (visibility_timeout, message, properties)
+            SELECT now(), m, p FROM unnest($1, $2) AS u(m, p)
+        ', '{SchemaName}', topic, subscription_name) USING messages, properties;
     END LOOP;
 END;
 $$ LANGUAGE plpgsql;",

--- a/knightbus-postgresql/tests/KnightBus.PostgreSql.Tests.Integration/PostgresBusTests.cs
+++ b/knightbus-postgresql/tests/KnightBus.PostgreSql.Tests.Integration/PostgresBusTests.cs
@@ -1,9 +1,13 @@
-﻿using System.Text.Json;
+﻿using System.Globalization;
+using System.Text.Json;
 using FluentAssertions;
 using KnightBus.Core;
+using KnightBus.Core.PreProcessors;
 using KnightBus.Messages;
 using KnightBus.PostgreSql.Management;
 using KnightBus.PostgreSql.Messages;
+using Npgsql;
+using NpgsqlTypes;
 using NUnit.Framework;
 
 namespace KnightBus.PostgreSql.Tests.Integration;
@@ -18,7 +22,7 @@ public class PostgresBusTests
     [OneTimeSetUp]
     public async Task OneTimeSetUp()
     {
-        _postgresBus = new PostgresBus(PostgresSetup.DataSource, new PostgresConfiguration());
+        _postgresBus = new PostgresBus(PostgresSetup.DataSource, new PostgresConfiguration(), []);
         _postgresQueueClient = new PostgresQueueClient<TestCommand>(
             PostgresSetup.DataSource,
             new MicrosoftJsonSerializer()
@@ -40,6 +44,14 @@ public class PostgresBusTests
             PostgresQueueName.Create(AutoMessageMapper.GetQueueName<TestCommand>()),
             default
         );
+        await PostgresSetup
+            .DataSource.CreateCommand(
+                @"
+DROP TABLE IF EXISTS knightbus.s_bus_test_topic_bus_sub;
+DROP TABLE IF EXISTS knightbus.dlq_bus_test_topic_bus_sub;
+DROP TABLE IF EXISTS knightbus.t_bus_test_topic;"
+            )
+            .ExecuteNonQueryAsync();
     }
 
     [SetUp]
@@ -141,8 +153,9 @@ public class PostgresBusTests
             .ToBlockingEnumerable()
             .ToList();
 
-        result[0].Message.MessageBody.Should().Be("For future from 0");
         result.Count.Should().Be(100_000);
+        // UPDATE ... RETURNING does not preserve the CTE's ORDER BY, so assert membership
+        result.Select(m => m.Message.MessageBody).Should().Contain("For future from 0");
     }
 
     [Test]
@@ -164,9 +177,180 @@ public class PostgresBusTests
         messages.Count.Should().Be(2);
         messages[0].Message.MessageBody.Should().Be("message body 1");
         messages[0].ReadCount.Should().Be(1);
+        messages[0].Properties.Should().BeEmpty();
         messages[1].Message.MessageBody.Should().Be("message body 2");
         messages[1].ReadCount.Should().Be(1);
+        messages[1].Properties.Should().BeEmpty();
     }
+
+    [Test]
+    public async Task SendAsync_WithPreProcessors_StoresPropertiesOnMessage()
+    {
+        var bus = new PostgresBus(
+            PostgresSetup.DataSource,
+            new PostgresConfiguration(),
+            [new TestPreProcessor()]
+        );
+
+        await bus.SendAsync<TestCommand>(
+            [
+                new TestCommand { MessageBody = "first" },
+                new TestCommand { MessageBody = "skip this one" },
+                new TestCommand { MessageBody = "third" },
+            ],
+            default
+        );
+
+        var messages = _postgresQueueClient
+            .GetMessagesAsync(3, 100, default)
+            .ToBlockingEnumerable()
+            .ToList();
+
+        messages.Count.Should().Be(3);
+        messages[0].Properties["trace_id"].Should().Be("first");
+        messages[1].Properties.Should().BeEmpty();
+        messages[2].Properties["trace_id"].Should().Be("third");
+    }
+
+    [Test]
+    public async Task SendAsync_ManyMessagesWithPreProcessors_StoresPropertiesOnMessage()
+    {
+        var bus = new PostgresBus(
+            PostgresSetup.DataSource,
+            new PostgresConfiguration(),
+            [new TestPreProcessor()]
+        );
+
+        // 50 or more messages take the binary COPY path
+        var commands = Enumerable
+            .Range(0, 60)
+            .Select(i => new TestCommand
+            {
+                MessageBody = i % 2 == 0 ? $"Message {i}" : $"skip {i}",
+            })
+            .ToList();
+        await bus.SendAsync<TestCommand>(commands, default);
+
+        var messages = _postgresQueueClient
+            .GetMessagesAsync(60, 100, default)
+            .ToBlockingEnumerable()
+            .ToList();
+
+        messages.Count.Should().Be(60);
+        foreach (var message in messages)
+        {
+            if (message.Message.MessageBody.StartsWith("skip"))
+                message.Properties.Should().BeEmpty();
+            else
+                message.Properties["trace_id"].Should().Be(message.Message.MessageBody);
+        }
+    }
+
+    [Test]
+    public async Task PublishAsync_WithPreProcessors_StoresPropertiesOnMessage()
+    {
+        await InitBusTestSubscription();
+        var bus = new PostgresBus(
+            PostgresSetup.DataSource,
+            new PostgresConfiguration(),
+            [new TestPreProcessor()]
+        );
+
+        var events = Enumerable
+            .Range(0, 6)
+            .Select(i => new BusTestEvent(i % 2 == 0 ? $"event {i}" : $"skip {i}"))
+            .ToList();
+        await bus.PublishAsync(events, default);
+
+        var messages = CreateBusTestSubscriptionClient()
+            .GetMessagesAsync(6, 100, default)
+            .ToBlockingEnumerable()
+            .ToList();
+
+        messages.Count.Should().Be(6);
+        foreach (var message in messages)
+        {
+            if (message.Message.Value.StartsWith("skip"))
+                message.Properties.Should().BeEmpty();
+            else
+                message.Properties["trace_id"].Should().Be(message.Message.Value);
+        }
+    }
+
+    [Test]
+    public async Task PublishAsync_LegacyTwoArgumentFunction_StillWorks()
+    {
+        await InitBusTestSubscription();
+
+        await using var connection = await PostgresSetup.DataSource.OpenConnectionAsync();
+        await using var cmd = new NpgsqlCommand(
+            "select knightbus.publish_events($1, $2)",
+            connection
+        );
+        cmd.Parameters.Add(
+            new NpgsqlParameter { Value = "bus_test_topic", NpgsqlDbType = NpgsqlDbType.Text }
+        );
+        cmd.Parameters.Add(
+            new NpgsqlParameter
+            {
+                Value = new[]
+                {
+                    new MicrosoftJsonSerializer().Serialize(new BusTestEvent("legacy")),
+                },
+                NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Jsonb,
+            }
+        );
+        await cmd.ExecuteNonQueryAsync();
+
+        var messages = CreateBusTestSubscriptionClient()
+            .GetMessagesAsync(1, 100, default)
+            .ToBlockingEnumerable()
+            .ToList();
+
+        messages.Single().Message.Value.Should().Be("legacy");
+        messages.Single().Properties.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task PublishAsync_MissingPropertiesOverload_CreatesItAndRetries()
+    {
+        await InitBusTestSubscription();
+        // A database initialized before 4.0.0 only has the two-argument function
+        await PostgresSetup
+            .DataSource.CreateCommand(
+                "DROP FUNCTION IF EXISTS knightbus.publish_events(text, jsonb[], jsonb[]);"
+            )
+            .ExecuteNonQueryAsync();
+        var bus = new PostgresBus(
+            PostgresSetup.DataSource,
+            new PostgresConfiguration(),
+            [new TestPreProcessor()]
+        );
+
+        await bus.PublishAsync(new BusTestEvent("healed"), default);
+
+        var messages = CreateBusTestSubscriptionClient()
+            .GetMessagesAsync(1, 100, default)
+            .ToBlockingEnumerable()
+            .ToList();
+
+        messages.Single().Message.Value.Should().Be("healed");
+        messages.Single().Properties["trace_id"].Should().Be("healed");
+    }
+
+    private static Task InitBusTestSubscription() =>
+        QueueInitializer.InitSubscription(
+            PostgresQueueName.Create(AutoMessageMapper.GetQueueName<BusTestEvent>()),
+            PostgresQueueName.Create(new BusTestEventSubscription().Name),
+            PostgresSetup.DataSource
+        );
+
+    private static PostgresSubscriptionClient<BusTestEvent> CreateBusTestSubscriptionClient() =>
+        new(
+            PostgresSetup.DataSource,
+            new MicrosoftJsonSerializer(),
+            new BusTestEventSubscription()
+        );
 
     [Test]
     public async Task GetMessages_visibility_timeout()
@@ -320,6 +504,33 @@ WHERE message_id = {message[0].Id}"
     }
 
     [Test]
+    public async Task Schedule_FractionalDelayUnderCommaDecimalCulture()
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo("sv-SE");
+        try
+        {
+            await _postgresBus.ScheduleAsync<TestCommand>(
+                [new TestCommand { MessageBody = "fractional delay" }],
+                TimeSpan.FromMilliseconds(1500),
+                default
+            );
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
+
+        await Task.Delay(2000);
+
+        var result = _postgresQueueClient
+            .GetMessagesAsync(1, 10, default)
+            .ToBlockingEnumerable()
+            .ToList();
+        result.Single().Message.MessageBody.Should().Be("fractional delay");
+    }
+
+    [Test]
     public async Task PeekDeadLetterMessagesAsync()
     {
         await _postgresBus.SendAsync<TestCommand>(
@@ -371,6 +582,49 @@ WHERE message_id = {message[0].Id}"
 public class TestCommand : IPostgresCommand
 {
     public string MessageBody { get; set; }
+}
+
+public class BusTestEvent : IPostgresEvent
+{
+    public string Value { get; set; }
+
+    public BusTestEvent(string value)
+    {
+        Value = value;
+    }
+}
+
+public class BusTestEventMapping : IMessageMapping<BusTestEvent>
+{
+    public string QueueName => "bus_test_topic";
+}
+
+public class BusTestEventSubscription : IEventSubscription<BusTestEvent>
+{
+    public string Name => "bus_sub";
+}
+
+public class TestPreProcessor : IMessagePreProcessor
+{
+    public Task<IDictionary<string, object>> PreProcess<T>(
+        T message,
+        CancellationToken cancellationToken
+    )
+        where T : IMessage
+    {
+        var body = message switch
+        {
+            TestCommand command => command.MessageBody,
+            BusTestEvent busEvent => busEvent.Value,
+            _ => "unknown",
+        };
+
+        // Mirrors AttachmentPreProcessor, which returns nothing for messages without attachments
+        IDictionary<string, object> properties = body.StartsWith("skip")
+            ? new Dictionary<string, object>()
+            : new Dictionary<string, object> { ["trace_id"] = body };
+        return Task.FromResult(properties);
+    }
 }
 
 public class TestMessageSettings : IProcessingSettings

--- a/knightbus-postgresql/tests/KnightBus.PostgreSql.Tests.Integration/PostgresMessageStateHandlerTests.cs
+++ b/knightbus-postgresql/tests/KnightBus.PostgreSql.Tests.Integration/PostgresMessageStateHandlerTests.cs
@@ -23,7 +23,8 @@ public class PostgresMessageStateHandlerTests : MessageStateHandlerTests<Postgre
         );
         _bus = new PostgresBus(
             PostgresSetup.DataSource,
-            new PostgresConfiguration { MessageSerializer = new MicrosoftJsonSerializer() }
+            new PostgresConfiguration { MessageSerializer = new MicrosoftJsonSerializer() },
+            []
         );
 
         await QueueInitializer.InitQueue(

--- a/knightbus-postgresql/tests/KnightBus.PostgreSql.Tests.Integration/PostgresQueueManagerTests.cs
+++ b/knightbus-postgresql/tests/KnightBus.PostgreSql.Tests.Integration/PostgresQueueManagerTests.cs
@@ -30,7 +30,8 @@ public class PostgresQueueManagerTests : QueueManagerTests<PostgresTestCommand>
         QueueType = QueueType.Queue;
         _bus = new PostgresBus(
             PostgresSetup.DataSource,
-            new PostgresConfiguration { MessageSerializer = new MicrosoftJsonSerializer() }
+            new PostgresConfiguration { MessageSerializer = new MicrosoftJsonSerializer() },
+            []
         );
 
         await QueueInitializer.InitQueue(

--- a/knightbus-postgresql/tests/KnightBus.PostgreSql.Tests.Integration/PostgresSubscriptionManagerTests.cs
+++ b/knightbus-postgresql/tests/KnightBus.PostgreSql.Tests.Integration/PostgresSubscriptionManagerTests.cs
@@ -33,7 +33,8 @@ public class PostgresSubscriptionManagerTests : QueueManagerTests<PostgresTestEv
         QueueType = QueueType.Subscription;
         _bus = new PostgresBus(
             PostgresSetup.DataSource,
-            new PostgresConfiguration { MessageSerializer = new MicrosoftJsonSerializer() }
+            new PostgresConfiguration { MessageSerializer = new MicrosoftJsonSerializer() },
+            []
         );
         await QueueInitializer.InitSubscription(
             PostgresQueueName.Create(AutoMessageMapper.GetQueueName<PostgresTestEvent>()),


### PR DESCRIPTION
`PostgresBus` now runs `IMessagePreProcessor` on send, schedule and publish, storing the returned properties in the existing `properties` column. Attachments and outgoing distributed tracing now work over PostgreSQL; the receive side already read the column, so no consumer changes were needed.

**Publish path:** `publish_events` gains a three-argument overload carrying properties. The two-argument overload is kept for older publishers, and a publisher that finds the new overload missing (a database initialized before 4.0.0) creates it and retries — this needs function-create rights on the `knightbus` schema, or the overload can be created up front with `QueueInitializer.InitPublishFunction`.

**Also in here:**
- Pre-processing runs before a connection is opened, so slow work like attachment uploads no longer holds a pooled connection or an open COPY transaction.
- The scheduled-delay interval is now a typed parameter instead of interpolated SQL, fixing `ScheduleAsync` with fractional delays under comma-decimal cultures (`22007` on batches under 50 messages).
- Docs updated: the "no attachments / no tracing on PostgreSQL" caveats are removed and the feature matrix flipped.

**Breaking:** the `PostgresBus` constructor takes `IEnumerable<IMessagePreProcessor>`; no change needed when resolving `IPostgresBus` through DI. `KnightBus.PostgreSql` bumped to 4.0.0.

Integration tests cover both insert paths with mixed empty/non-empty properties, multi-event publish pairing, the legacy overload, the self-healing retry, and the culture fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176nyGkxqpWKrvJAEpwYtnx