### PR TITLE
feat: enable nullable reference types across all projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+# 2026-08-26
+
+### Nullable reference types enabled across all packages
+Ships with each package's next version bump. All public APIs now carry nullability annotations;
+the signatures themselves are unchanged.
+* Consumers with nullable enabled that implement the extension points get new warnings until they
+  match the annotations: `ICommandWithAttachment.Attachment` is now `IMessageAttachment?` (CS8767)
+  and `ISingletonLockManager.TryLockAsync` now returns `Task<ISingletonLockHandle?>` (CS8613) —
+  the null contracts were always there, the types now say so
+* Fixed in `KnightBus.Azure.Storage`: `BlobSagaStore.Create` returned saga data without a
+  `ConcurrencyStamp` when it had to create the blob container first (the first saga in a fresh
+  storage account), which silently disabled optimistic concurrency for that saga instance until
+  its next update
+* Misconfiguration now fails fast instead of deep inside a client library: a missing
+  `ConnectionString` throws `InvalidOperationException` when the Redis/Postgres client is built,
+  and the channel factories throw `InvalidOperationException` if a receiver cannot be constructed
+
 # 2026-08-25
 
 ### KnightBus.Redis 17.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,20 @@
 # 2026-08-26
 
 ### Nullable reference types enabled across all packages
-Ships with each package's next version bump. All public APIs now carry nullability annotations;
-the signatures themselves are unchanged.
+All public APIs now carry nullability annotations; the signatures themselves are unchanged. Released
+as a minor bump for the seventeen packages whose compiled surface changed: `KnightBus.Core` 18.3.0,
+`KnightBus.Core.Management` 18.3.0, `KnightBus.Messages` 7.3.0, `KnightBus.Host` 18.2.0,
+`KnightBus.Azure.ServiceBus` 24.1.0, `KnightBus.Azure.ServiceBus.Management` 4.2.0,
+`KnightBus.Azure.Storage` 18.2.0, `KnightBus.Azure.Storage.Management` 4.2.0, `KnightBus.Redis`
+17.1.0, `KnightBus.Redis.Management` 3.2.0, `KnightBus.PostgreSql` 4.1.0, `KnightBus.Nats` 7.1.0,
+`KnightBus.SqlServer` 17.1.0, `KnightBus.Schedule` 15.2.0, `KnightBus.Newtonsoft` 5.2.0,
+`KnightBus.ApplicationInsights` 14.1.0 and `KnightBus.NewRelic` 13.1.0.
+
+The other nine packages are byte-for-byte unchanged and are not republished. The four PostgreSql
+satellites, `KnightBus.Nats.Messages` and `KnightBus.OpenTelemetry` were already annotated, so
+inheriting the setting from `Directory.Build.props` compiles them identically;
+`KnightBus.Azure.ServiceBus.Messages`, `KnightBus.Azure.Storage.Messages` and
+`KnightBus.Redis.Messages` hold only marker interfaces, which have nothing to annotate.
 * Consumers with nullable enabled that implement the extension points get new warnings until they
   match the annotations: `ICommandWithAttachment.Attachment` is now `IMessageAttachment?` (CS8767)
   and `ISingletonLockManager.TryLockAsync` now returns `Task<ISingletonLockHandle?>` (CS8613) —

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,8 @@
     <RepositoryUrl>https://github.com/BookBeat/knightbus</RepositoryUrl>
     <PackageIcon>knightbus-64.png</PackageIcon>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>$(WarningsAsErrors);Nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/features/attachments.md
+++ b/docs/features/attachments.md
@@ -15,7 +15,7 @@ Implement `ICommandWithAttachment` on the command alongside its transport interf
 public class ImportFile : IServiceBusCommand, ICommandWithAttachment
 {
     public string Description { get; set; }
-    public IMessageAttachment Attachment { get; set; }
+    public IMessageAttachment? Attachment { get; set; }
 }
 ```
 

--- a/docs/features/singleton-processing.md
+++ b/docs/features/singleton-processing.md
@@ -79,7 +79,7 @@ picks it up.
 ```csharp
 public interface ISingletonLockManager
 {
-    Task<ISingletonLockHandle> TryLockAsync(
+    Task<ISingletonLockHandle?> TryLockAsync(
         string lockId,
         TimeSpan lockPeriod,
         CancellationToken cancellationToken

--- a/docs/reference/marker-interfaces.md
+++ b/docs/reference/marker-interfaces.md
@@ -30,7 +30,7 @@ in KnightBus.
 | `ICommand` | One logical consumer. | Implement a transport-specific descendant instead. |
 | `IEvent` | Fan-out to many subscriptions. | Implement a transport-specific descendant instead. |
 | `IRequest` | Request/response. | Implement `INatsRequest`; only NATS supports requests. |
-| `ICommandWithAttachment` | Adds an out-of-band payload. | Requires a registered attachment provider on **both** sender and receiver. Adds `IMessageAttachment Attachment { get; set; }`. |
+| `ICommandWithAttachment` | Adds an out-of-band payload. | Requires a registered attachment provider on **both** sender and receiver. Adds `IMessageAttachment? Attachment { get; set; }`. |
 
 ### Transport interfaces
 
@@ -46,7 +46,7 @@ in KnightBus.
 public class ImportFile : IServiceBusCommand, ICommandWithAttachment
 {
     public string Description { get; set; }
-    public IMessageAttachment Attachment { get; set; }
+    public IMessageAttachment? Attachment { get; set; }
 }
 ```
 

--- a/samples/KnightBus.Samples.Azure.AspireHost/KnightBus.Samples.Azure.AspireHost.csproj
+++ b/samples/KnightBus.Samples.Azure.AspireHost/KnightBus.Samples.Azure.AspireHost.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <UserSecretsId>b2ad9cab-ed30-4aba-b11f-df0144c0ee91</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/KnightBus.Samples.Azure.ServiceBus/Messages.cs
+++ b/samples/KnightBus.Samples.Azure.ServiceBus/Messages.cs
@@ -6,7 +6,7 @@ namespace KnightBus.Samples.Azure.ServiceBus;
 
 public class OtherSampleServiceBusMessage : IServiceBusCommand
 {
-    public string SomeProperty { get; set; }
+    public string SomeProperty { get; set; } = null!;
 }
 
 class SampleServiceBusEventMapping : IMessageMapping<SampleServiceBusEvent>
@@ -26,12 +26,12 @@ class SampleServiceBusMessageMapping
 
 public class SampleServiceBusMessage : IServiceBusCommand
 {
-    public string Message { get; set; }
+    public string Message { get; set; } = null!;
 }
 
 public class SampleServiceBusEvent : IServiceBusEvent
 {
-    public string Message { get; set; }
+    public string Message { get; set; } = null!;
 }
 
 public class OtherSampleServiceBusMessageMapping : IMessageMapping<OtherSampleServiceBusMessage>

--- a/samples/KnightBus.Samples.Azure.Storage/Program.cs
+++ b/samples/KnightBus.Samples.Azure.Storage/Program.cs
@@ -81,8 +81,8 @@ internal class Program
 
     class SampleStorageBusMessage : IStorageQueueCommand, ICommandWithAttachment
     {
-        public string Message { get; set; }
-        public IMessageAttachment Attachment { get; set; }
+        public string Message { get; set; } = null!;
+        public IMessageAttachment? Attachment { get; set; }
     }
 
     class SampleStorageBusMessageMapping : IMessageMapping<SampleStorageBusMessage>
@@ -93,7 +93,7 @@ internal class Program
     class SampleSagaStartMessage : IStorageQueueCommand
     {
         public string Id { get; set; } = "c1e06984-d946-4c70-a8aa-e32e44c6407e";
-        public string Message { get; set; }
+        public string Message { get; set; } = null!;
     }
 
     class SampleSagaStartMessageMapping : IMessageMapping<SampleSagaStartMessage>
@@ -128,7 +128,7 @@ internal class Program
             CancellationToken cancellationToken
         )
         {
-            using (var streamReader = new StreamReader(message.Attachment.Stream))
+            using (var streamReader = new StreamReader(message.Attachment!.Stream))
             {
                 Console.WriteLine($"Received command: '{message.Message}'");
                 Console.WriteLine($"Attach file contents:'{streamReader.ReadToEnd()}'");

--- a/samples/KnightBus.Samples.Nats/Program.cs
+++ b/samples/KnightBus.Samples.Nats/Program.cs
@@ -60,7 +60,7 @@ class Program
             );
             foreach (var reply in response)
             {
-                Console.WriteLine(reply.Reply);
+                Console.WriteLine(reply?.Reply);
             }
         }
 
@@ -75,12 +75,12 @@ class Program
 
     class SampleNatsMessage : INatsRequest
     {
-        public string Message { get; set; }
+        public string Message { get; set; } = null!;
     }
 
     class SampleNatsCommand : INatsCommand, ICommandWithAttachment
     {
-        public IMessageAttachment Attachment { get; set; }
+        public IMessageAttachment? Attachment { get; set; }
     }
 
     class SampleNatsCommandMapping : IMessageMapping<SampleNatsCommand>
@@ -90,7 +90,7 @@ class Program
 
     class SampleNatsEvent : INatsEvent
     {
-        public string Message { get; set; }
+        public string Message { get; set; } = null!;
     }
 
     class SampleSubscription1 : IEventSubscription<SampleNatsEvent>
@@ -105,7 +105,7 @@ class Program
 
     class SampleNatsReply
     {
-        public string Reply { get; set; }
+        public string Reply { get; set; } = null!;
     }
 
     class SampleNatsMessageMapping : IMessageMapping<SampleNatsMessage>
@@ -161,7 +161,7 @@ class Program
     {
         public Task ProcessAsync(SampleNatsCommand message, CancellationToken cancellationToken)
         {
-            using (var s = new StreamReader(message.Attachment.Stream))
+            using (var s = new StreamReader(message.Attachment!.Stream))
             {
                 Console.WriteLine($"Command {s.ReadToEnd()}");
             }

--- a/samples/KnightBus.Samples.PostgreSql/KnightBus.Samples.PostgreSql.csproj
+++ b/samples/KnightBus.Samples.PostgreSql/KnightBus.Samples.PostgreSql.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/KnightBus.Samples.Redis/Program.cs
+++ b/samples/KnightBus.Samples.Redis/Program.cs
@@ -70,12 +70,12 @@ class Program
 
     class SampleRedisCommand : IRedisCommand
     {
-        public string Message { get; set; }
+        public string Message { get; set; } = null!;
     }
 
     class SampleRedisEvent : IRedisEvent
     {
-        public string Message { get; set; }
+        public string Message { get; set; } = null!;
     }
 
     class SampleRedisSagaStarterCommand : IRedisCommand

--- a/samples/KnightBus.Samples.Schedule/Program.cs
+++ b/samples/KnightBus.Samples.Schedule/Program.cs
@@ -72,7 +72,7 @@ public class InMemoryLockManager : ISingletonLockManager
 {
     private readonly ConcurrentDictionary<string, int> _heldLocks = new();
 
-    public Task<ISingletonLockHandle> TryLockAsync(
+    public Task<ISingletonLockHandle?> TryLockAsync(
         string lockId,
         TimeSpan lockPeriod,
         CancellationToken cancellationToken
@@ -85,10 +85,10 @@ public class InMemoryLockManager : ISingletonLockManager
                 await Task.Delay(TimeSpan.FromSeconds(50));
                 _heldLocks.TryRemove(lockId, out _);
             });
-            return Task.FromResult<ISingletonLockHandle>(new InMemoryLockHandle(lockId));
+            return Task.FromResult<ISingletonLockHandle?>(new InMemoryLockHandle(lockId));
         }
 
-        return Task.FromResult<ISingletonLockHandle>(null);
+        return Task.FromResult<ISingletonLockHandle?>(null);
     }
 
     public Task InitializeAsync()

--- a/src/KnightBus.ApplicationInsights/ApplicationInsightsExtensions.cs
+++ b/src/KnightBus.ApplicationInsights/ApplicationInsightsExtensions.cs
@@ -23,7 +23,7 @@ public static class ApplicationInsightsExtensions
         TelemetryConfiguration telemetryConfiguration
     )
     {
-        QuickPulseTelemetryProcessor processor = null;
+        QuickPulseTelemetryProcessor? processor = null;
 
         telemetryConfiguration
             .TelemetryProcessorChainBuilder.Use(next =>

--- a/src/KnightBus.ApplicationInsights/KnightBus.ApplicationInsights.csproj
+++ b/src/KnightBus.ApplicationInsights/KnightBus.ApplicationInsights.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Application Insights for KnightBus</Description>
-    <Version>14.0.0$(VersionSuffix)</Version>
+    <Version>14.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;applicationinsights;azure;</PackageTags>
   </PropertyGroup>
 

--- a/src/KnightBus.Azure.ServiceBus.Management/KnightBus.Azure.ServiceBus.Management.csproj
+++ b/src/KnightBus.Azure.ServiceBus.Management/KnightBus.Azure.ServiceBus.Management.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Azure Service Bus Transport Management for KnightBus</Description>
-    <Version>4.1.0$(VersionSuffix)</Version>
+    <Version>4.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/src/KnightBus.Azure.ServiceBus.Management/ServiceBusQueueManager.cs
+++ b/src/KnightBus.Azure.ServiceBus.Management/ServiceBusQueueManager.cs
@@ -69,7 +69,7 @@ public class ServiceBusQueueManager : IQueueManager, IQueueMessageSender, IAsync
             .ToList();
     }
 
-    private static QueueMessage MapToQueueMessage(ServiceBusReceivedMessage m, object error)
+    private static QueueMessage MapToQueueMessage(ServiceBusReceivedMessage m, object? error)
     {
         return new QueueMessage(
             Encoding.UTF8.GetString(m.Body),

--- a/src/KnightBus.Azure.ServiceBus/CHANGELOG.md
+++ b/src/KnightBus.Azure.ServiceBus/CHANGELOG.md
@@ -1,5 +1,13 @@
 ﻿# KnightBus.Azure.ServiceBus Changelog
 
+## 24.1.0
+### Changed
+- Nullable reference types are enabled. `IServiceBusConfiguration.FullyQualifiedNamespace` and
+  `Credential` are now `string?`/`TokenCredential?`, matching what `ServiceBusConfiguration` already
+  declared: they are null in connection-string mode, as `ConnectionString` is under managed identity
+- The queue and topic channel factories throw `InvalidOperationException` when a channel receiver
+  cannot be constructed, instead of surfacing as a `NullReferenceException` at an unrelated call site
+
 
 ## 17.0.0
 ### Changed 

--- a/src/KnightBus.Azure.ServiceBus/IServiceBusConfiguration.cs
+++ b/src/KnightBus.Azure.ServiceBus/IServiceBusConfiguration.cs
@@ -10,10 +10,10 @@ public interface IServiceBusConfiguration : ITransportConfiguration
     /// <summary>
     /// Used when using a <see cref="TokenCredential"/>. The fully qualified Service Bus namespace to connect to. This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>
     /// </summary>
-    string FullyQualifiedNamespace { get; set; }
+    string? FullyQualifiedNamespace { get; set; }
 
     /// <summary>
     /// The Azure managed identity credential to use for authorization. Access controls may be specified by the Service Bus namespace.
     /// </summary>
-    TokenCredential Credential { get; set; }
+    TokenCredential? Credential { get; set; }
 }

--- a/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Azure Service Bus Transport for KnightBus</Description>
-    <Version>24.0.0$(VersionSuffix)</Version>
+    <Version>24.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/src/KnightBus.Azure.ServiceBus/ServiceBusChannelReceiverBase.cs
+++ b/src/KnightBus.Azure.ServiceBus/ServiceBusChannelReceiverBase.cs
@@ -18,7 +18,7 @@ internal abstract class ServiceBusChannelReceiverBase<T> : IChannelReceiver
     private readonly IMessageSerializer _serializer;
     protected readonly ILogger Log;
     private CancellationToken _cancellationToken;
-    private ServiceBusProcessor _client;
+    private ServiceBusProcessor? _client;
     private int _deadLetterLimit;
     protected readonly IClientFactory ClientFactory;
     protected readonly ServiceBusAdministrationClient ManagementClient;
@@ -60,7 +60,7 @@ internal abstract class ServiceBusChannelReceiverBase<T> : IChannelReceiver
                 try
                 {
                     Log.LogInformation($"Closing ServiceBus channel receiver for {typeof(T).Name}");
-                    await _client.CloseAsync(CancellationToken.None);
+                    await _client!.CloseAsync(CancellationToken.None);
                 }
                 catch (Exception)
                 {

--- a/src/KnightBus.Azure.ServiceBus/ServiceBusChannelReceiverBase.cs
+++ b/src/KnightBus.Azure.ServiceBus/ServiceBusChannelReceiverBase.cs
@@ -18,7 +18,7 @@ internal abstract class ServiceBusChannelReceiverBase<T> : IChannelReceiver
     private readonly IMessageSerializer _serializer;
     protected readonly ILogger Log;
     private CancellationToken _cancellationToken;
-    private ServiceBusProcessor? _client;
+    private ServiceBusProcessor _client = null!;
     private int _deadLetterLimit;
     protected readonly IClientFactory ClientFactory;
     protected readonly ServiceBusAdministrationClient ManagementClient;
@@ -60,7 +60,7 @@ internal abstract class ServiceBusChannelReceiverBase<T> : IChannelReceiver
                 try
                 {
                     Log.LogInformation($"Closing ServiceBus channel receiver for {typeof(T).Name}");
-                    await _client!.CloseAsync(CancellationToken.None);
+                    await _client.CloseAsync(CancellationToken.None);
                 }
                 catch (Exception)
                 {

--- a/src/KnightBus.Azure.ServiceBus/ServiceBusConfiguration.cs
+++ b/src/KnightBus.Azure.ServiceBus/ServiceBusConfiguration.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using Azure.Core;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;

--- a/src/KnightBus.Azure.ServiceBus/ServiceBusExtensions.cs
+++ b/src/KnightBus.Azure.ServiceBus/ServiceBusExtensions.cs
@@ -7,7 +7,7 @@ public static class ServiceBusExtensions
 {
     public static IServiceCollection UseServiceBus(
         this IServiceCollection collection,
-        Action<IServiceBusConfiguration> config = null
+        Action<IServiceBusConfiguration>? config = null
     )
     {
         var configuration = new ServiceBusConfiguration();

--- a/src/KnightBus.Azure.ServiceBus/ServiceBusMessageStateHandler.cs
+++ b/src/KnightBus.Azure.ServiceBus/ServiceBusMessageStateHandler.cs
@@ -34,7 +34,7 @@ internal class ServiceBusMessageStateHandler<T> : IMessageStateHandler<T>
     public IDictionary<string, string> MessageProperties =>
         _sbMessage
             .ApplicationProperties?.Where(kvp => kvp.Value is string)
-            .ToDictionary(k => k.Key, k => k.Value.ToString()) ?? new Dictionary<string, string>();
+            .ToDictionary(k => k.Key, k => k.Value.ToString()!) ?? new Dictionary<string, string>();
 
     public async Task CompleteAsync()
     {

--- a/src/KnightBus.Azure.ServiceBus/ServiceBusQueueChannelFactory.cs
+++ b/src/KnightBus.Azure.ServiceBus/ServiceBusQueueChannelFactory.cs
@@ -16,7 +16,7 @@ internal class ServiceBusQueueChannelFactory : ITransportChannelFactory
 
     public IChannelReceiver Create(
         Type messageType,
-        IEventSubscription subscription,
+        IEventSubscription? subscription,
         IProcessingSettings processingSettings,
         IMessageSerializer serializer,
         IHostConfiguration configuration,
@@ -24,7 +24,7 @@ internal class ServiceBusQueueChannelFactory : ITransportChannelFactory
     )
     {
         var queueReaderType = typeof(ServiceBusQueueChannelReceiver<>).MakeGenericType(messageType);
-        var queueReader = (IChannelReceiver)
+        var queueReader =
             Activator.CreateInstance(
                 queueReaderType,
                 processingSettings,
@@ -32,8 +32,9 @@ internal class ServiceBusQueueChannelFactory : ITransportChannelFactory
                 Configuration,
                 configuration,
                 processor
-            );
-        return queueReader;
+            ) as IChannelReceiver;
+        return queueReader
+            ?? throw new InvalidOperationException("ChannelReceiver could not be created");
     }
 
     public bool CanCreate(Type messageType)

--- a/src/KnightBus.Azure.ServiceBus/ServiceBusTopicChannelFactory.cs
+++ b/src/KnightBus.Azure.ServiceBus/ServiceBusTopicChannelFactory.cs
@@ -16,7 +16,7 @@ internal class ServiceBusTopicChannelFactory : ITransportChannelFactory
 
     public IChannelReceiver Create(
         Type messageType,
-        IEventSubscription subscription,
+        IEventSubscription? subscription,
         IProcessingSettings processingSettings,
         IMessageSerializer serializer,
         IHostConfiguration configuration,
@@ -24,7 +24,7 @@ internal class ServiceBusTopicChannelFactory : ITransportChannelFactory
     )
     {
         var queueReaderType = typeof(ServiceBusTopicChannelReceiver<>).MakeGenericType(messageType);
-        var queueReader = (IChannelReceiver)
+        var queueReader =
             Activator.CreateInstance(
                 queueReaderType,
                 processingSettings,
@@ -33,8 +33,9 @@ internal class ServiceBusTopicChannelFactory : ITransportChannelFactory
                 Configuration,
                 configuration,
                 processor
-            );
-        return queueReader;
+            ) as IChannelReceiver;
+        return queueReader
+            ?? throw new InvalidOperationException("ChannelReceiver could not be created");
     }
 
     public bool CanCreate(Type messageType)

--- a/src/KnightBus.Azure.Storage.Management/KnightBus.Azure.Storage.Management.csproj
+++ b/src/KnightBus.Azure.Storage.Management/KnightBus.Azure.Storage.Management.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Azure Storage Transport Management for KnightBus</Description>
-    <Version>4.1.0$(VersionSuffix)</Version>
+    <Version>4.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;azure storage;blob;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/src/KnightBus.Azure.Storage/BlobStorageMessageAttachmentProvider.cs
+++ b/src/KnightBus.Azure.Storage/BlobStorageMessageAttachmentProvider.cs
@@ -43,7 +43,7 @@ public class BlobStorageMessageAttachmentProvider : IMessageAttachmentProvider
         _options = options ?? new BlobStorageAttachmentOptions();
     }
 
-    public async Task<IMessageAttachment> GetAttachmentAsync(
+    public async Task<IMessageAttachment?> GetAttachmentAsync(
         string queueName,
         string id,
         CancellationToken cancellationToken = default(CancellationToken)
@@ -110,7 +110,7 @@ public class BlobStorageMessageAttachmentProvider : IMessageAttachmentProvider
         requiredMetadata.ToList().ForEach(x => metadata[x.Key] = x.Value); // Merge the dictionaries, on collisions, override keys in user's metadata with requiredMetadata
 
         var id = Guid.NewGuid().ToString("N");
-        string contentEncoding = null;
+        string? contentEncoding = null;
         if (_options.EnableCompression)
         {
             id = $"{id}{CompressedFileExtension}";
@@ -234,7 +234,7 @@ public class BlobStorageMessageAttachmentProvider : IMessageAttachmentProvider
         CancellationToken cancellationToken
     )
     {
-        Stream blobStream = null;
+        Stream? blobStream = null;
         try
         {
             // Compress into memory first: a result within the threshold uploads as a

--- a/src/KnightBus.Azure.Storage/BlobStorageMessageAttachmentProvider.cs
+++ b/src/KnightBus.Azure.Storage/BlobStorageMessageAttachmentProvider.cs
@@ -43,7 +43,7 @@ public class BlobStorageMessageAttachmentProvider : IMessageAttachmentProvider
         _options = options ?? new BlobStorageAttachmentOptions();
     }
 
-    public async Task<IMessageAttachment?> GetAttachmentAsync(
+    public async Task<IMessageAttachment> GetAttachmentAsync(
         string queueName,
         string id,
         CancellationToken cancellationToken = default(CancellationToken)

--- a/src/KnightBus.Azure.Storage/KnightBus.Azure.Storage.csproj
+++ b/src/KnightBus.Azure.Storage/KnightBus.Azure.Storage.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Azure Storage Transport for KnightBus</Description>
-    <Version>18.1.0$(VersionSuffix)</Version>
+    <Version>18.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;azure storage;blob;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/src/KnightBus.Azure.Storage/Sagas/BlobSagaStore.cs
+++ b/src/KnightBus.Azure.Storage/Sagas/BlobSagaStore.cs
@@ -42,9 +42,11 @@ public class BlobSagaStore : ISagaStore
                 throw new SagaNotFoundException(partitionKey, id);
 
             var downloadInfo = await blob.DownloadAsync(ct).ConfigureAwait(false);
-            T data = await JsonSerializer
-                .DeserializeAsync<T>(downloadInfo.Value.Content, cancellationToken: ct)
-                .ConfigureAwait(false);
+            T data = (
+                await JsonSerializer
+                    .DeserializeAsync<T>(downloadInfo.Value.Content, cancellationToken: ct)
+                    .ConfigureAwait(false)
+            )!;
             return new SagaData<T>
             {
                 Data = data,
@@ -114,7 +116,7 @@ public class BlobSagaStore : ISagaStore
             when (e.Status == 404 && e.ErrorCode == "ContainerNotFound")
         {
             await _container.CreateIfNotExistsAsync(cancellationToken: ct).ConfigureAwait(false);
-            await Create(partitionKey, id, data, ttl, ct);
+            return await Create(partitionKey, id, data, ttl, ct).ConfigureAwait(false);
         }
         catch (RequestFailedException e) when (e.Status == 412 || e.Status == 409)
         {
@@ -146,7 +148,7 @@ public class BlobSagaStore : ISagaStore
                             Metadata = properties.Value.Metadata,
                             Conditions = new AppendBlobRequestConditions
                             {
-                                IfMatch = new ETag(sagaData.ConcurrencyStamp),
+                                IfMatch = new ETag(sagaData.ConcurrencyStamp!),
                             },
                         },
                         ct
@@ -177,7 +179,7 @@ public class BlobSagaStore : ISagaStore
         {
             var conditions = new AppendBlobRequestConditions
             {
-                IfMatch = new ETag(sagaData.ConcurrencyStamp),
+                IfMatch = new ETag(sagaData.ConcurrencyStamp!),
             };
             await blob.DeleteAsync(conditions: conditions, cancellationToken: ct)
                 .ConfigureAwait(false);

--- a/src/KnightBus.Azure.Storage/Singleton/BlobLockManager.cs
+++ b/src/KnightBus.Azure.Storage/Singleton/BlobLockManager.cs
@@ -15,15 +15,15 @@ namespace KnightBus.Azure.Storage.Singleton;
 internal class BlobLockManager : ISingletonLockManager
 {
     private readonly IStorageBusConfiguration _configuration;
-    private BlobContainerClient _client;
+    private BlobContainerClient? _client;
     private readonly IBlobLockScheme _lockScheme;
 
-    public BlobLockManager(string connectionString, IBlobLockScheme lockScheme = null)
+    public BlobLockManager(string connectionString, IBlobLockScheme? lockScheme = null)
         : this(new StorageBusConfiguration(connectionString), lockScheme) { }
 
     public BlobLockManager(
         IStorageBusConfiguration configuration,
-        IBlobLockScheme lockScheme = null
+        IBlobLockScheme? lockScheme = null
     )
     {
         _configuration = configuration;
@@ -43,13 +43,13 @@ internal class BlobLockManager : ISingletonLockManager
         return Task.CompletedTask;
     }
 
-    public async Task<ISingletonLockHandle> TryLockAsync(
+    public async Task<ISingletonLockHandle?> TryLockAsync(
         string lockId,
         TimeSpan lockPeriod,
         CancellationToken cancellationToken
     )
     {
-        var blob = _client.GetBlobClient(Path.Combine(_lockScheme.Directory, lockId));
+        var blob = _client!.GetBlobClient(Path.Combine(_lockScheme.Directory, lockId));
 
         var lease = await TryAcquireLeaseAsync(blob, lockPeriod, cancellationToken)
             .ConfigureAwait(false);
@@ -89,7 +89,7 @@ internal class BlobLockManager : ISingletonLockManager
         );
     }
 
-    private static async Task<BlobLease> TryAcquireLeaseAsync(
+    private static async Task<BlobLease?> TryAcquireLeaseAsync(
         BlobClient blob,
         TimeSpan leasePeriod,
         CancellationToken cancellationToken

--- a/src/KnightBus.Azure.Storage/Singleton/BlobLockManager.cs
+++ b/src/KnightBus.Azure.Storage/Singleton/BlobLockManager.cs
@@ -15,7 +15,7 @@ namespace KnightBus.Azure.Storage.Singleton;
 internal class BlobLockManager : ISingletonLockManager
 {
     private readonly IStorageBusConfiguration _configuration;
-    private BlobContainerClient? _client;
+    private BlobContainerClient _client = null!;
     private readonly IBlobLockScheme _lockScheme;
 
     public BlobLockManager(string connectionString, IBlobLockScheme? lockScheme = null)
@@ -49,7 +49,7 @@ internal class BlobLockManager : ISingletonLockManager
         CancellationToken cancellationToken
     )
     {
-        var blob = _client!.GetBlobClient(Path.Combine(_lockScheme.Directory, lockId));
+        var blob = _client.GetBlobClient(Path.Combine(_lockScheme.Directory, lockId));
 
         var lease = await TryAcquireLeaseAsync(blob, lockPeriod, cancellationToken)
             .ConfigureAwait(false);

--- a/src/KnightBus.Azure.Storage/StorageExtensions.cs
+++ b/src/KnightBus.Azure.Storage/StorageExtensions.cs
@@ -34,7 +34,7 @@ public static class StorageExtensions
 
     public static IServiceCollection UseBlobStorage(
         this IServiceCollection services,
-        Action<IStorageBusConfiguration> config = null
+        Action<IStorageBusConfiguration>? config = null
     )
     {
         var storageConfig = new StorageBusConfiguration();

--- a/src/KnightBus.Azure.Storage/StorageOptions.cs
+++ b/src/KnightBus.Azure.Storage/StorageOptions.cs
@@ -8,8 +8,6 @@ using KnightBus.Newtonsoft;
 
 namespace KnightBus.Azure.Storage;
 
-#nullable enable
-
 public interface IStorageBusConfiguration : ITransportConfiguration
 {
     /// <summary>
@@ -48,7 +46,7 @@ public class StorageBusConfiguration : IStorageBusConfiguration
     /// <summary>
     /// <remarks>Should be left blank if using managed identity</remarks>
     /// </summary>
-    public string ConnectionString { get; set; }
+    public string? ConnectionString { get; set; }
     public IMessageSerializer MessageSerializer { get; set; } = new NewtonsoftSerializer();
 
     /// <summary>

--- a/src/KnightBus.Azure.Storage/StorageQueueChannelFactory.cs
+++ b/src/KnightBus.Azure.Storage/StorageQueueChannelFactory.cs
@@ -16,7 +16,7 @@ internal class StorageQueueChannelFactory : ITransportChannelFactory
 
     public IChannelReceiver Create(
         Type messageType,
-        IEventSubscription subscription,
+        IEventSubscription? subscription,
         IProcessingSettings processingSettings,
         IMessageSerializer serializer,
         IHostConfiguration configuration,
@@ -24,7 +24,7 @@ internal class StorageQueueChannelFactory : ITransportChannelFactory
     )
     {
         var queueReaderType = typeof(StorageQueueChannelReceiver<>).MakeGenericType(messageType);
-        var queueReader = (IChannelReceiver)
+        var queueReader =
             Activator.CreateInstance(
                 queueReaderType,
                 processingSettings,
@@ -32,8 +32,9 @@ internal class StorageQueueChannelFactory : ITransportChannelFactory
                 processor,
                 configuration,
                 Configuration
-            );
-        return queueReader;
+            ) as IChannelReceiver;
+        return queueReader
+            ?? throw new InvalidOperationException("ChannelReceiver could not be created");
     }
 
     public bool CanCreate(Type messageType)

--- a/src/KnightBus.Azure.Storage/StorageQueueChannelReceiver.cs
+++ b/src/KnightBus.Azure.Storage/StorageQueueChannelReceiver.cs
@@ -16,13 +16,13 @@ namespace KnightBus.Azure.Storage;
 internal class StorageQueueChannelReceiver<T> : IChannelReceiver
     where T : class, IStorageQueueCommand
 {
-    private IStorageQueueClient _storageQueueClient;
+    private IStorageQueueClient _storageQueueClient = null!;
     private readonly IMessageSerializer _serializer;
     private readonly IStorageBusConfiguration _storageOptions;
     private readonly IMessageProcessor _processor;
     private readonly IHostConfiguration _hostConfiguration;
     public IProcessingSettings Settings { get; set; }
-    private StorageQueueMessagePump _messagePump;
+    private StorageQueueMessagePump _messagePump = null!;
 
     public StorageQueueChannelReceiver(
         IProcessingSettings settings,

--- a/src/KnightBus.Azure.Storage/StorageQueueClient.cs
+++ b/src/KnightBus.Azure.Storage/StorageQueueClient.cs
@@ -20,9 +20,9 @@ public interface IStorageQueueClient
     Task<int> GetDeadLetterCountAsync();
     Task<List<StorageQueueMessage>> PeekDeadLettersAsync<T>(int count)
         where T : IStorageQueueCommand;
-    Task<StorageQueueMessage> ReceiveDeadLetterAsync<T>()
+    Task<StorageQueueMessage?> ReceiveDeadLetterAsync<T>()
         where T : IStorageQueueCommand;
-    Task RequeueDeadLettersAsync<T>(int count, Func<T, bool> shouldRequeue)
+    Task RequeueDeadLettersAsync<T>(int count, Func<T, bool>? shouldRequeue)
         where T : IStorageQueueCommand;
     Task CompleteAsync(StorageQueueMessage message);
     Task AbandonByErrorAsync(StorageQueueMessage message, TimeSpan? visibilityTimeout);
@@ -129,7 +129,7 @@ public class StorageQueueClient(
             var properties = await preProcessor.PreProcess(message, cancellationToken);
             foreach (var property in properties)
             {
-                storageMessage.Properties[property.Key] = property.Value.ToString();
+                storageMessage.Properties[property.Key] = property.Value.ToString()!;
             }
         }
 
@@ -163,7 +163,7 @@ public class StorageQueueClient(
         return PeekMessagesAsync<T>(count, _dlQueue);
     }
 
-    public async Task RequeueDeadLettersAsync<T>(int count, Func<T, bool> shouldRequeue)
+    public async Task RequeueDeadLettersAsync<T>(int count, Func<T, bool>? shouldRequeue)
         where T : IStorageQueueCommand
     {
         for (var i = 0; i < count; i++)
@@ -195,7 +195,7 @@ public class StorageQueueClient(
         }
     }
 
-    public async Task<StorageQueueMessage> ReceiveDeadLetterAsync<T>()
+    public async Task<StorageQueueMessage?> ReceiveDeadLetterAsync<T>()
         where T : IStorageQueueCommand
     {
         var messages = await GetMessagesAsync<T>(1, null, _dlQueue).ConfigureAwait(false);

--- a/src/KnightBus.Azure.Storage/StorageQueueMessage.cs
+++ b/src/KnightBus.Azure.Storage/StorageQueueMessage.cs
@@ -20,9 +20,9 @@ public class StorageQueueMessage
         internal set => Properties["_bmid"] = value;
     }
 
-    internal string QueueMessageId { get; set; }
-    public string PopReceipt { get; internal set; }
-    public IMessage Message { get; internal set; }
+    internal string QueueMessageId { get; set; } = null!;
+    public string PopReceipt { get; internal set; } = null!;
+    public IMessage Message { get; internal set; } = null!;
     public int DequeueCount { get; set; }
     public Dictionary<string, string> Properties { get; internal set; } = new();
     public DateTimeOffset? Time { get; internal set; }

--- a/src/KnightBus.Core.Management/IQueueMessageAttachmentProvider.cs
+++ b/src/KnightBus.Core.Management/IQueueMessageAttachmentProvider.cs
@@ -10,7 +10,7 @@ public interface IQueueMessageAttachmentProvider
     /// Gets the attachment for the given queue and attachment id.
     /// </summary>
     /// <returns>The attachment if it exists, otherwise <see langword="null" /></returns>
-    Task<QueueMessageAttachment> GetAttachment(
+    Task<QueueMessageAttachment?> GetAttachment(
         string queue,
         Dictionary<string, string> messageProperties,
         CancellationToken cancellationToken

--- a/src/KnightBus.Core.Management/KnightBus.Core.Management.csproj
+++ b/src/KnightBus.Core.Management/KnightBus.Core.Management.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Shared core management functionallity for the KnightBus framework</Description>
-    <Version>18.2.0$(VersionSuffix)</Version>
+    <Version>18.3.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/KnightBus.Core.Management/QueueMessage.cs
+++ b/src/KnightBus.Core.Management/QueueMessage.cs
@@ -6,7 +6,7 @@ namespace KnightBus.Core.Management;
 
 public record QueueMessage(
     string Body,
-    string? Error,
+    string Error,
     DateTimeOffset? Time,
     DateTimeOffset? ScheduledTime,
     int DeliveryCount,
@@ -17,7 +17,7 @@ public record QueueMessage(
 {
     public QueueMessage(
         string Body,
-        string? Error,
+        string Error,
         DateTimeOffset? Time,
         DateTimeOffset? ScheduledTime,
         int DeliveryCount,

--- a/src/KnightBus.Core.Management/QueueMessage.cs
+++ b/src/KnightBus.Core.Management/QueueMessage.cs
@@ -6,7 +6,7 @@ namespace KnightBus.Core.Management;
 
 public record QueueMessage(
     string Body,
-    string Error,
+    string? Error,
     DateTimeOffset? Time,
     DateTimeOffset? ScheduledTime,
     int DeliveryCount,
@@ -17,7 +17,7 @@ public record QueueMessage(
 {
     public QueueMessage(
         string Body,
-        string Error,
+        string? Error,
         DateTimeOffset? Time,
         DateTimeOffset? ScheduledTime,
         int DeliveryCount,
@@ -32,7 +32,7 @@ public record QueueMessage(
             ScheduledTime,
             DeliveryCount,
             MessageId,
-            Properties.ToDictionary(x => x.Key, x => x.Value.ToString()),
+            Properties.ToDictionary(x => x.Key, x => x.Value.ToString()!),
             SequenceNumber
         ) { }
 };

--- a/src/KnightBus.Core.Management/QueueMessageAttachmentProvider.cs
+++ b/src/KnightBus.Core.Management/QueueMessageAttachmentProvider.cs
@@ -24,9 +24,6 @@ public class QueueMessageAttachmentProvider(IMessageAttachmentProvider attachmen
             cancellationToken
         );
 
-        if (attachment is null)
-            return null;
-
         return new QueueMessageAttachment(
             attachment.Stream,
             attachment.ContentType,

--- a/src/KnightBus.Core.Management/QueueMessageAttachmentProvider.cs
+++ b/src/KnightBus.Core.Management/QueueMessageAttachmentProvider.cs
@@ -8,7 +8,7 @@ namespace KnightBus.Core.Management;
 public class QueueMessageAttachmentProvider(IMessageAttachmentProvider attachmentProvider)
     : IQueueMessageAttachmentProvider
 {
-    public async Task<QueueMessageAttachment> GetAttachment(
+    public async Task<QueueMessageAttachment?> GetAttachment(
         string queue,
         Dictionary<string, string> messageProperties,
         CancellationToken cancellationToken

--- a/src/KnightBus.Core/AutoMessageMapper.cs
+++ b/src/KnightBus.Core/AutoMessageMapper.cs
@@ -17,7 +17,7 @@ public static class AutoMessageMapper
     private static void MapFromMessageAssembly(Type type)
     {
         var assembly = type.Assembly;
-        if (AlreadyMappedAssemblies.ContainsKey(assembly.FullName))
+        if (AlreadyMappedAssemblies.ContainsKey(assembly.FullName!))
             return;
 
         // This is so that we do not call RegisterMappingsFromAssembly twice for the same assembly.
@@ -29,11 +29,11 @@ public static class AutoMessageMapper
             Semaphore.Wait();
 
             // If the assembly was mapped while we were waiting for the semaphore to release, return
-            if (AlreadyMappedAssemblies.ContainsKey(assembly.FullName))
+            if (AlreadyMappedAssemblies.ContainsKey(assembly.FullName!))
                 return;
 
             MessageMapper.RegisterMappingsFromAssembly(assembly);
-            AlreadyMappedAssemblies.AddOrUpdate(assembly.FullName, false, (s, b) => b);
+            AlreadyMappedAssemblies.AddOrUpdate(assembly.FullName!, false, (s, b) => b);
         }
         finally
         {

--- a/src/KnightBus.Core/CHANGELOG.md
+++ b/src/KnightBus.Core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # KnightBus.Core Changelog
 
+# 18.3.0
+* Nullable reference types are enabled. Public APIs carry nullability annotations; no signature changed.
+  Implementations of the annotated extension points get new warnings until they match:
+  `ITransportChannelFactory.Create` takes an `IEventSubscription?` (command processors have no
+  subscription), `ITransportConfiguration.ConnectionString` is `string?` (null when using managed
+  identity), `ISingletonLockManager.TryLockAsync` returns `Task<ISingletonLockHandle?>` (null already
+  meant "lock held elsewhere"), `IPipelineInformation.Subscription` is nullable, and
+  `SagaData.ConcurrencyStamp` is `string?` (stores that do not use stamps leave it unset)
+
 # 7.1.0
 * Add support for metadata in `IMessageAttachement`s
 

--- a/src/KnightBus.Core/DefaultMiddlewares/AttachmentMiddleware.cs
+++ b/src/KnightBus.Core/DefaultMiddlewares/AttachmentMiddleware.cs
@@ -32,11 +32,11 @@ public class AttachmentMiddleware : IMessageProcessorMiddleware
     )
         where T : class, IMessage
     {
-        IMessageAttachment attachment = null;
+        IMessageAttachment? attachment = null;
         var queueName = AutoMessageMapper.GetQueueName<T>();
         try
         {
-            string attachmentId = null;
+            string? attachmentId = null;
             if (typeof(ICommandWithAttachment).IsAssignableFrom(typeof(T)))
             {
                 attachmentId = AttachmentUtility
@@ -58,7 +58,7 @@ public class AttachmentMiddleware : IMessageProcessorMiddleware
                 try
                 {
                     await _attachmentProvider
-                        .DeleteAttachmentAsync(queueName, attachmentId, cancellationToken)
+                        .DeleteAttachmentAsync(queueName, attachmentId!, cancellationToken)
                         .ConfigureAwait(false);
                 }
                 catch (Exception e)

--- a/src/KnightBus.Core/DefaultMiddlewares/ErrorHandlingMiddleware.cs
+++ b/src/KnightBus.Core/DefaultMiddlewares/ErrorHandlingMiddleware.cs
@@ -23,7 +23,7 @@ public class ErrorHandlingMiddleware : IMessageProcessorMiddleware
     )
         where T : class, IMessage
     {
-        T message = null;
+        T? message = null;
         try
         {
             message = messageStateHandler.GetMessage();

--- a/src/KnightBus.Core/DependencyInjection/MicrosoftDependencyInjection.cs
+++ b/src/KnightBus.Core/DependencyInjection/MicrosoftDependencyInjection.cs
@@ -8,9 +8,9 @@ namespace KnightBus.Core.DependencyInjection;
 public class MicrosoftDependencyInjection : IDependencyInjection
 {
     private readonly IServiceProvider _provider;
-    private readonly IServiceScope _scope;
+    private readonly IServiceScope? _scope;
 
-    public MicrosoftDependencyInjection(IServiceProvider provider, IServiceScope scope = null)
+    public MicrosoftDependencyInjection(IServiceProvider provider, IServiceScope? scope = null)
     {
         _provider = provider;
         _scope = scope;

--- a/src/KnightBus.Core/DistributedTracing/DefaultDistributedTracingProvider.cs
+++ b/src/KnightBus.Core/DistributedTracing/DefaultDistributedTracingProvider.cs
@@ -5,7 +5,7 @@ namespace KnightBus.Core.DistributedTracing;
 
 public class DefaultDistributedTracingProvider : IDistributedTracingProvider
 {
-    private string _traceId;
+    private string? _traceId;
 
     public void SetProperties(IDictionary<string, string> properties)
     {

--- a/src/KnightBus.Core/GenericMessagePump.cs
+++ b/src/KnightBus.Core/GenericMessagePump.cs
@@ -19,10 +19,10 @@ public abstract class GenericMessagePump<TInternalRepresentation, TMessageInterf
     protected readonly IProcessingSettings Settings;
     protected readonly ILogger Log;
     private readonly SemaphoreSlim _maxConcurrent;
-    private Task _runningTask;
+    private Task? _runningTask;
     private CancellationTokenSource _pumpDelayCancellationTokenSource = new();
     private CancellationToken _pumpCancellationToken = CancellationToken.None;
-    private string _queueName;
+    private string _queueName = null!;
 
     protected GenericMessagePump(IProcessingSettings settings, ILogger log)
     {
@@ -217,7 +217,7 @@ public abstract class GenericMessagePump<TInternalRepresentation, TMessageInterf
     /// <param name="lockDuration">Duration to lock message for other consumers</param>
     /// <typeparam name="TMessage">The type of message</typeparam>
     /// <returns></returns>
-    protected abstract IAsyncEnumerable<TInternalRepresentation> GetMessagesAsync<TMessage>(
+    protected abstract IAsyncEnumerable<TInternalRepresentation?> GetMessagesAsync<TMessage>(
         int count,
         TimeSpan? lockDuration
     )

--- a/src/KnightBus.Core/IMessageAttachmentProvider.cs
+++ b/src/KnightBus.Core/IMessageAttachmentProvider.cs
@@ -9,8 +9,7 @@ namespace KnightBus.Core;
 /// </summary>
 public interface IMessageAttachmentProvider
 {
-    /// <returns>The attachment if it exists, otherwise <see langword="null" /></returns>
-    Task<IMessageAttachment?> GetAttachmentAsync(
+    Task<IMessageAttachment> GetAttachmentAsync(
         string queueName,
         string id,
         CancellationToken cancellationToken = default(CancellationToken)

--- a/src/KnightBus.Core/IMessageAttachmentProvider.cs
+++ b/src/KnightBus.Core/IMessageAttachmentProvider.cs
@@ -9,7 +9,8 @@ namespace KnightBus.Core;
 /// </summary>
 public interface IMessageAttachmentProvider
 {
-    Task<IMessageAttachment> GetAttachmentAsync(
+    /// <returns>The attachment if it exists, otherwise <see langword="null" /></returns>
+    Task<IMessageAttachment?> GetAttachmentAsync(
         string queueName,
         string id,
         CancellationToken cancellationToken = default(CancellationToken)

--- a/src/KnightBus.Core/IPipelineInformation.cs
+++ b/src/KnightBus.Core/IPipelineInformation.cs
@@ -6,7 +6,7 @@ namespace KnightBus.Core;
 public interface IPipelineInformation
 {
     Type ProcessorInterfaceType { get; }
-    IEventSubscription Subscription { get; }
+    IEventSubscription? Subscription { get; }
     IProcessingSettings ProcessingSettings { get; }
     IHostConfiguration HostConfiguration { get; }
 }

--- a/src/KnightBus.Core/ITransportChannelFactory.cs
+++ b/src/KnightBus.Core/ITransportChannelFactory.cs
@@ -11,7 +11,7 @@ public interface ITransportChannelFactory
     ITransportConfiguration Configuration { get; set; }
     IChannelReceiver Create(
         Type messageType,
-        IEventSubscription subscription,
+        IEventSubscription? subscription,
         IProcessingSettings processingSettings,
         IMessageSerializer serializer,
         IHostConfiguration configuration,

--- a/src/KnightBus.Core/ITransportConfiguration.cs
+++ b/src/KnightBus.Core/ITransportConfiguration.cs
@@ -7,6 +7,6 @@ namespace KnightBus.Core;
 /// </summary>
 public interface ITransportConfiguration
 {
-    string ConnectionString { get; set; }
+    string? ConnectionString { get; set; }
     IMessageSerializer MessageSerializer { get; set; }
 }

--- a/src/KnightBus.Core/KnightBus.Core.csproj
+++ b/src/KnightBus.Core/KnightBus.Core.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Shared core functionallity for the KnightBus framework</Description>
-    <Version>18.2.2$(VersionSuffix)</Version>
+    <Version>18.3.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/KnightBus.Core/MessageAttachment.cs
+++ b/src/KnightBus.Core/MessageAttachment.cs
@@ -11,7 +11,7 @@ public class MessageAttachment : IMessageAttachment
         string filename,
         string contentType,
         Stream stream,
-        Dictionary<string, string> metadata = null
+        Dictionary<string, string>? metadata = null
     )
     {
         Filename = filename;

--- a/src/KnightBus.Core/MessageMapper.cs
+++ b/src/KnightBus.Core/MessageMapper.cs
@@ -26,7 +26,7 @@ internal static class MessageMapper
             IMessageMapping mappingInstance;
             if (typeof(IMessageMapping).IsAssignableFrom(mapping))
             {
-                mappingInstance = (IMessageMapping)Activator.CreateInstance(mapping);
+                mappingInstance = (IMessageMapping)Activator.CreateInstance(mapping)!;
             }
             else
             {

--- a/src/KnightBus.Core/MicrosoftJsonSerializer.cs
+++ b/src/KnightBus.Core/MicrosoftJsonSerializer.cs
@@ -10,12 +10,13 @@ namespace KnightBus.Core;
 
 internal class AttachmentTypeMapping : JsonConverter<IMessageAttachment>
 {
-    public override IMessageAttachment Read(
+    public override IMessageAttachment? Read(
         ref Utf8JsonReader reader,
         Type typeToConvert,
         JsonSerializerOptions options
     )
     {
+        //Attachments are never serialized; AttachmentMiddleware re-hydrates them
         return null;
     }
 
@@ -33,7 +34,7 @@ public class MicrosoftJsonSerializer : IMessageSerializer
 {
     private readonly JsonSerializerOptions _options;
 
-    public MicrosoftJsonSerializer(JsonSerializerOptions options = null)
+    public MicrosoftJsonSerializer(JsonSerializerOptions? options = null)
     {
         _options = options ?? new JsonSerializerOptions();
         _options.Converters.Add(new AttachmentTypeMapping());
@@ -47,17 +48,17 @@ public class MicrosoftJsonSerializer : IMessageSerializer
 
     public T Deserialize<T>(ReadOnlySpan<byte> serialized)
     {
-        return JsonSerializer.Deserialize<T>(serialized, _options);
+        return JsonSerializer.Deserialize<T>(serialized, _options)!;
     }
 
     public T Deserialize<T>(ReadOnlyMemory<byte> serialized)
     {
-        return JsonSerializer.Deserialize<T>(serialized.Span, _options);
+        return JsonSerializer.Deserialize<T>(serialized.Span, _options)!;
     }
 
     public Task<T> Deserialize<T>(Stream serialized)
     {
-        return JsonSerializer.DeserializeAsync<T>(serialized, _options).AsTask();
+        return JsonSerializer.DeserializeAsync<T>(serialized, _options).AsTask()!;
     }
 
     public string ContentType => "application/json";

--- a/src/KnightBus.Core/Sagas/Saga.cs
+++ b/src/KnightBus.Core/Sagas/Saga.cs
@@ -43,22 +43,22 @@ public interface ISaga<T> : ISaga
 
 public class SagaData<T>
 {
-    public T Data { get; set; }
-    public string ConcurrencyStamp { get; set; }
+    public T Data { get; set; } = default!;
+    public string? ConcurrencyStamp { get; set; }
 }
 
 public abstract class Saga<T> : ISaga<T>
 {
     public abstract string PartitionKey { get; }
-    public string Id { get; set; }
-    public SagaData<T> SagaData { private get; set; }
+    public string Id { get; set; } = null!;
+    public SagaData<T> SagaData { private get; set; } = null!;
     public T Data
     {
         get { return SagaData.Data; }
         set { SagaData.Data = value; }
     }
     public ISagaMessageMapper MessageMapper { get; } = new SagaMessageMapper();
-    public ISagaStore SagaStore { get; set; }
+    public ISagaStore SagaStore { get; set; } = null!;
 
     public abstract TimeSpan TimeToLive { get; }
 

--- a/src/KnightBus.Core/Sagas/SagaMessageMapper.cs
+++ b/src/KnightBus.Core/Sagas/SagaMessageMapper.cs
@@ -41,7 +41,7 @@ internal class SagaMessageMapper : ISagaMessageMapper
     {
         try
         {
-            return _mappings[typeof(TMessage)] as Func<TMessage, string>;
+            return (_mappings[typeof(TMessage)] as Func<TMessage, string>)!;
         }
         catch (KeyNotFoundException)
         {

--- a/src/KnightBus.Core/Sagas/SagaMiddleWare.cs
+++ b/src/KnightBus.Core/Sagas/SagaMiddleWare.cs
@@ -43,7 +43,7 @@ public class SagaMiddleware : IMessageProcessorMiddleware
             var sagaHandlerType = typeof(SagaHandler<,>).MakeGenericType(sagaDataType, typeof(T));
             var message = messageStateHandler.GetMessage();
             var sagaHandler = (ISagaHandler)
-                Activator.CreateInstance(sagaHandlerType, _sagaStore, processor, message);
+                Activator.CreateInstance(sagaHandlerType, _sagaStore, processor, message)!;
             try
             {
                 await sagaHandler.Initialize(cancellationToken).ConfigureAwait(false);

--- a/src/KnightBus.Core/Singleton/ISingletonLockManager.cs
+++ b/src/KnightBus.Core/Singleton/ISingletonLockManager.cs
@@ -6,7 +6,7 @@ namespace KnightBus.Core.Singleton;
 
 public interface ISingletonLockManager
 {
-    Task<ISingletonLockHandle> TryLockAsync(
+    Task<ISingletonLockHandle?> TryLockAsync(
         string lockId,
         TimeSpan lockPeriod,
         CancellationToken cancellationToken

--- a/src/KnightBus.Core/Singleton/SingletonTimerScope.cs
+++ b/src/KnightBus.Core/Singleton/SingletonTimerScope.cs
@@ -14,7 +14,7 @@ public class SingletonTimerScope : IDisposable
     private readonly CancellationTokenSource _cts;
     private readonly object _releaseLockObject = new();
     private Task _runningTask;
-    private Task _releaseTask;
+    private Task? _releaseTask;
 
     /// <summary>
     /// Completes when the renewal loop has stopped and the lock release has finished

--- a/src/KnightBus.Host/HostConfiguration.cs
+++ b/src/KnightBus.Host/HostConfiguration.cs
@@ -6,7 +6,7 @@ namespace KnightBus.Host;
 
 internal class HostConfiguration : IHostConfiguration
 {
-    public IDependencyInjection DependencyInjection { get; set; }
-    public ILogger Log { get; set; }
+    public IDependencyInjection DependencyInjection { get; set; } = null!;
+    public ILogger Log { get; set; } = null!;
     public TimeSpan ShutdownGracePeriod { get; set; } = TimeSpan.FromSeconds(30);
 }

--- a/src/KnightBus.Host/KnightBus.Host.csproj
+++ b/src/KnightBus.Host/KnightBus.Host.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>KnightBus Host</Description>
-    <Version>18.1.1$(VersionSuffix)</Version>
+    <Version>18.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/KnightBus.Host/KnightBusHost.cs
+++ b/src/KnightBus.Host/KnightBusHost.cs
@@ -17,7 +17,7 @@ namespace KnightBus.Host;
 public class KnightBusHost : IHostedService
 {
     private IHostConfiguration _configuration;
-    private MessageProcessorLocator _locator;
+    private MessageProcessorLocator? _locator;
     private readonly CancellationTokenSource _shutdownToken = new CancellationTokenSource();
     private readonly CancellationTokenSource _teardownToken = new CancellationTokenSource();
     private static readonly TimeSpan DrainPollingInterval = TimeSpan.FromMilliseconds(100);

--- a/src/KnightBus.Host/KnightBusHost.cs
+++ b/src/KnightBus.Host/KnightBusHost.cs
@@ -17,7 +17,6 @@ namespace KnightBus.Host;
 public class KnightBusHost : IHostedService
 {
     private IHostConfiguration _configuration;
-    private MessageProcessorLocator? _locator;
     private readonly CancellationTokenSource _shutdownToken = new CancellationTokenSource();
     private readonly CancellationTokenSource _teardownToken = new CancellationTokenSource();
     private static readonly TimeSpan DrainPollingInterval = TimeSpan.FromMilliseconds(100);
@@ -63,12 +62,12 @@ public class KnightBusHost : IHostedService
 
         if (transports.Any())
         {
-            _locator = new MessageProcessorLocator(
+            var locator = new MessageProcessorLocator(
                 _configuration,
                 transports.SelectMany(transport => transport.TransportChannelFactories).ToArray(),
                 _teardownToken.Token
             );
-            Receivers.AddRange(_locator.CreateReceivers());
+            Receivers.AddRange(locator.CreateReceivers());
             _configuration.Log.LogInformation("Starting receivers");
             foreach (var receiver in Receivers)
             {

--- a/src/KnightBus.Host/KnightBusHostExtensions.cs
+++ b/src/KnightBus.Host/KnightBusHostExtensions.cs
@@ -9,7 +9,7 @@ public static class KnightBusHostExtensions
 {
     public static IHostBuilder UseKnightBus(
         this IHostBuilder builder,
-        Action<IHostConfiguration> configuration = null
+        Action<IHostConfiguration>? configuration = null
     )
     {
         IHostConfiguration conf = new HostConfiguration();

--- a/src/KnightBus.Host/MessageProcessing/Factories/RequestProcessorFactory.cs
+++ b/src/KnightBus.Host/MessageProcessing/Factories/RequestProcessorFactory.cs
@@ -20,7 +20,7 @@ internal class RequestProcessorFactory : MessageProcessorFactoryBase, IProcessor
     public IMessageProcessor GetProcessor(Type processorInterface)
     {
         var requestProcessorType = typeof(RequestProcessor<>).MakeGenericType(
-            GetProcessorTypes(processorInterface).ResponseType!
+            processorInterface.GenericTypeArguments[1]
         );
         return (IMessageProcessor)
             Activator.CreateInstance(requestProcessorType, processorInterface)!;

--- a/src/KnightBus.Host/MessageProcessing/Factories/RequestProcessorFactory.cs
+++ b/src/KnightBus.Host/MessageProcessing/Factories/RequestProcessorFactory.cs
@@ -20,9 +20,9 @@ internal class RequestProcessorFactory : MessageProcessorFactoryBase, IProcessor
     public IMessageProcessor GetProcessor(Type processorInterface)
     {
         var requestProcessorType = typeof(RequestProcessor<>).MakeGenericType(
-            GetProcessorTypes(processorInterface).ResponseType
+            GetProcessorTypes(processorInterface).ResponseType!
         );
         return (IMessageProcessor)
-            Activator.CreateInstance(requestProcessorType, processorInterface);
+            Activator.CreateInstance(requestProcessorType, processorInterface)!;
     }
 }

--- a/src/KnightBus.Host/MessageProcessing/Factories/StreamRequestProcessorFactory.cs
+++ b/src/KnightBus.Host/MessageProcessing/Factories/StreamRequestProcessorFactory.cs
@@ -20,7 +20,7 @@ internal class StreamRequestProcessorFactory : MessageProcessorFactoryBase, IPro
     public IMessageProcessor GetProcessor(Type processorInterface)
     {
         var requestProcessorType = typeof(StreamRequestProcessor<>).MakeGenericType(
-            GetProcessorTypes(processorInterface).ResponseType!
+            processorInterface.GenericTypeArguments[1]
         );
         return (IMessageProcessor)
             Activator.CreateInstance(requestProcessorType, processorInterface)!;

--- a/src/KnightBus.Host/MessageProcessing/Factories/StreamRequestProcessorFactory.cs
+++ b/src/KnightBus.Host/MessageProcessing/Factories/StreamRequestProcessorFactory.cs
@@ -20,9 +20,9 @@ internal class StreamRequestProcessorFactory : MessageProcessorFactoryBase, IPro
     public IMessageProcessor GetProcessor(Type processorInterface)
     {
         var requestProcessorType = typeof(StreamRequestProcessor<>).MakeGenericType(
-            GetProcessorTypes(processorInterface).ResponseType
+            GetProcessorTypes(processorInterface).ResponseType!
         );
         return (IMessageProcessor)
-            Activator.CreateInstance(requestProcessorType, processorInterface);
+            Activator.CreateInstance(requestProcessorType, processorInterface)!;
     }
 }

--- a/src/KnightBus.Host/MessageProcessing/ProcessorTypes.cs
+++ b/src/KnightBus.Host/MessageProcessing/ProcessorTypes.cs
@@ -6,8 +6,8 @@ internal struct ProcessorTypes
 {
     public ProcessorTypes(
         Type messageType,
-        Type responseType,
-        Type subscriptionType,
+        Type? responseType,
+        Type? subscriptionType,
         Type settingsType
     )
     {
@@ -18,8 +18,8 @@ internal struct ProcessorTypes
     }
 
     public Type MessageType { get; }
-    public Type ResponseType { get; }
-    public Type SubscriptionType { get; }
+    public Type? ResponseType { get; }
+    public Type? SubscriptionType { get; }
     public Type SettingsType { get; }
 
     public override string ToString()

--- a/src/KnightBus.Host/PipelineInformation.cs
+++ b/src/KnightBus.Host/PipelineInformation.cs
@@ -8,7 +8,7 @@ internal class PipelineInformation : IPipelineInformation
 {
     public PipelineInformation(
         Type processorInterfaceType,
-        IEventSubscription subscription,
+        IEventSubscription? subscription,
         IProcessingSettings processingSettings,
         IHostConfiguration hostConfiguration
     )
@@ -20,7 +20,7 @@ internal class PipelineInformation : IPipelineInformation
     }
 
     public Type ProcessorInterfaceType { get; }
-    public IEventSubscription Subscription { get; }
+    public IEventSubscription? Subscription { get; }
     public IProcessingSettings ProcessingSettings { get; }
     public IHostConfiguration HostConfiguration { get; }
 }

--- a/src/KnightBus.Host/Singleton/SingletonChannelReceiver.cs
+++ b/src/KnightBus.Host/Singleton/SingletonChannelReceiver.cs
@@ -13,7 +13,7 @@ internal class SingletonChannelReceiver : IChannelReceiver
     private readonly ISingletonLockManager _lockManager;
     private readonly ILogger _log;
     private readonly CancellationToken? _teardownToken;
-    private SingletonTimerScope _singletonScope;
+    private SingletonTimerScope? _singletonScope;
     private readonly string _lockId;
     internal string LockId => _lockId;
     public IProcessingSettings Settings { get; set; }
@@ -27,7 +27,7 @@ internal class SingletonChannelReceiver : IChannelReceiver
     //Incremented for every successful lock acquisition, so a stale watcher from a previous
     //acquisition cannot re-enable polling after the lock has already been re-acquired
     private int _acquisitionGeneration;
-    private Task _pollingLoop;
+    private Task? _pollingLoop;
 
     /// <summary>
     /// Completes when the lock held by this receiver has been released
@@ -38,7 +38,7 @@ internal class SingletonChannelReceiver : IChannelReceiver
         IChannelReceiver channelReceiver,
         ISingletonLockManager lockManager,
         ILogger log,
-        string lockId = null,
+        string? lockId = null,
         CancellationToken? teardownToken = null
     )
     {
@@ -46,7 +46,7 @@ internal class SingletonChannelReceiver : IChannelReceiver
         _lockManager = lockManager;
         _log = log;
         _teardownToken = teardownToken;
-        _lockId = lockId ?? channelReceiver.GetType().FullName;
+        _lockId = lockId ?? channelReceiver.GetType().FullName!;
         //MaxConcurrent and Prefetch must have specific  values to work with a singleton implementation.
         //Override those and let the other values be set from the specific implementation
         Settings = new SingletonProcessingSettings

--- a/src/KnightBus.Host/TcpAliveListenerPlugin.cs
+++ b/src/KnightBus.Host/TcpAliveListenerPlugin.cs
@@ -13,7 +13,7 @@ public class TcpAliveListenerPlugin : IStoppablePlugin, IDisposable
     private readonly ILogger _log;
     private readonly int _port;
     private readonly CancellationTokenSource _stopTokenSource = new();
-    private CancellationTokenSource _listenerTokenSource;
+    private CancellationTokenSource? _listenerTokenSource;
     private Task _listenerTask = Task.CompletedTask;
 
     public TcpAliveListenerPlugin(

--- a/src/KnightBus.Host/TransportStarterFactory.cs
+++ b/src/KnightBus.Host/TransportStarterFactory.cs
@@ -43,12 +43,12 @@ internal class TransportStarterFactory
             throw new TransportMissingException(processorTypes.MessageType);
 
         var processingSettings = (IProcessingSettings)
-            Activator.CreateInstance(processorTypes.SettingsType);
+            Activator.CreateInstance(processorTypes.SettingsType)!;
 
         var eventSubscription =
             processorTypes.SubscriptionType == null
                 ? null
-                : (IEventSubscription)Activator.CreateInstance(processorTypes.SubscriptionType);
+                : (IEventSubscription)Activator.CreateInstance(processorTypes.SubscriptionType)!;
         var pipelineInformation = new PipelineInformation(
             processorInterface,
             eventSubscription,
@@ -86,7 +86,7 @@ internal class TransportStarterFactory
     private IChannelReceiver WrapSingletonReceiver(
         IChannelReceiver channelReceiver,
         Type type,
-        IEventSubscription subscription
+        IEventSubscription? subscription
     )
     {
         if (typeof(ISingletonProcessor).IsAssignableFrom(type))

--- a/src/KnightBus.Messages/ICommandWithAttachment.cs
+++ b/src/KnightBus.Messages/ICommandWithAttachment.cs
@@ -6,5 +6,5 @@
 /// </summary>
 public interface ICommandWithAttachment
 {
-    IMessageAttachment Attachment { get; set; }
+    IMessageAttachment? Attachment { get; set; }
 }

--- a/src/KnightBus.Messages/KnightBus.Messages.csproj
+++ b/src/KnightBus.Messages/KnightBus.Messages.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Base KnightBus Message Interfaces</Description>
-    <Version>7.2.0$(VersionSuffix)</Version>
+    <Version>7.3.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;messaging;</PackageTags>
   </PropertyGroup>
 </Project>

--- a/src/KnightBus.Nats.Messages/KnightBus.Nats.Messages.csproj
+++ b/src/KnightBus.Nats.Messages/KnightBus.Nats.Messages.csproj
@@ -5,7 +5,6 @@
     <Description>NATS Messages for KnightBus</Description>
     <Version>1.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;nats;queues;messaging</PackageTags>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/KnightBus.Nats/KnightBus.Nats.csproj
+++ b/src/KnightBus.Nats/KnightBus.Nats.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>NATS for KnightBus</Description>
-    <Version>7.0.0$(VersionSuffix)</Version>
+    <Version>7.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;nats;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/src/KnightBus.Nats/NatsBus.cs
+++ b/src/KnightBus.Nats/NatsBus.cs
@@ -19,7 +19,7 @@ public interface INatsBus
         CancellationToken cancellationToken = default
     )
         where T : INatsRequest;
-    IEnumerable<TResponse> RequestStream<T, TResponse>(
+    IEnumerable<TResponse?> RequestStream<T, TResponse>(
         INatsRequest command,
         CancellationToken cancellationToken = default
     )
@@ -92,7 +92,7 @@ public class NatsBus : INatsBus
         return serializer.Deserialize<TResponse>(reply.Data.AsSpan());
     }
 
-    public IEnumerable<TResponse> RequestStream<T, TResponse>(
+    public IEnumerable<TResponse?> RequestStream<T, TResponse>(
         INatsRequest command,
         CancellationToken cancellationToken = default
     )

--- a/src/KnightBus.Nats/NatsChannelFactory.cs
+++ b/src/KnightBus.Nats/NatsChannelFactory.cs
@@ -16,7 +16,7 @@ public class NatsChannelFactory : ITransportChannelFactory
 
     public IChannelReceiver Create(
         Type messageType,
-        IEventSubscription subscription,
+        IEventSubscription? subscription,
         IProcessingSettings processingSettings,
         IMessageSerializer serializer,
         IHostConfiguration configuration,
@@ -24,7 +24,7 @@ public class NatsChannelFactory : ITransportChannelFactory
     )
     {
         var readerType = typeof(NatsQueueChannelReceiver<>).MakeGenericType(messageType);
-        var reader = (IChannelReceiver)
+        var reader =
             Activator.CreateInstance(
                 readerType,
                 processingSettings,
@@ -33,9 +33,10 @@ public class NatsChannelFactory : ITransportChannelFactory
                 processor,
                 Configuration,
                 subscription
-            );
+            ) as IChannelReceiver;
 
-        return reader;
+        return reader
+            ?? throw new InvalidOperationException("ChannelReceiver could not be created");
     }
 
     public bool CanCreate(Type messageType)

--- a/src/KnightBus.Nats/NatsExtensions.cs
+++ b/src/KnightBus.Nats/NatsExtensions.cs
@@ -8,7 +8,7 @@ public static class NatsExtensions
 {
     public static IServiceCollection UseNats(
         this IServiceCollection services,
-        Action<INatsConfiguration> configuration = null
+        Action<INatsConfiguration>? configuration = null
     )
     {
         var natsConfiguration = new NatsConfiguration();

--- a/src/KnightBus.Nats/NatsQueueChannelReceiver.cs
+++ b/src/KnightBus.Nats/NatsQueueChannelReceiver.cs
@@ -15,13 +15,13 @@ public class NatsQueueChannelReceiver<T> : IChannelReceiver
     private readonly IHostConfiguration _hostConfiguration;
     private readonly IMessageProcessor _processor;
     private readonly INatsConfiguration _configuration;
-    private readonly IEventSubscription _subscription;
+    private readonly IEventSubscription? _subscription;
     private const string CommandQueueGroup = "qg";
     public IProcessingSettings Settings { get; set; }
     private readonly ConnectionFactory _factory;
     private readonly ILogger _log;
     private CancellationToken _cancellationToken;
-    private IConnection _connection;
+    private IConnection _connection = null!;
     private readonly SemaphoreSlim _maxConcurrent;
 
     public NatsQueueChannelReceiver(
@@ -30,7 +30,7 @@ public class NatsQueueChannelReceiver<T> : IChannelReceiver
         IHostConfiguration hostConfiguration,
         IMessageProcessor processor,
         INatsConfiguration configuration,
-        IEventSubscription subscription
+        IEventSubscription? subscription
     )
     {
         Settings = settings;

--- a/src/KnightBus.Nats/NatsTransport.cs
+++ b/src/KnightBus.Nats/NatsTransport.cs
@@ -38,7 +38,7 @@ public interface INatsConfiguration : ITransportConfiguration
 
 public class NatsConfiguration : INatsConfiguration
 {
-    public string ConnectionString
+    public string? ConnectionString
     {
         get => Options?.Url;
         set => Options.Url = value;

--- a/src/KnightBus.NewRelic/KnightBus.NewRelic.csproj
+++ b/src/KnightBus.NewRelic/KnightBus.NewRelic.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>KnightBus.NewRelicMiddleware</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>NewRelic.Agent.Api for KnightBus</Description>
-    <Version>13.0.0$(VersionSuffix)</Version>
+    <Version>13.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;apm;newrelic.agent.api</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/KnightBus.NewRelic/NewRelicMessageMiddleware.cs
+++ b/src/KnightBus.NewRelic/NewRelicMessageMiddleware.cs
@@ -18,7 +18,7 @@ public class NewRelicMessageMiddleware : IMessageProcessorMiddleware
     )
         where T : class, IMessage
     {
-        var messageName = typeof(T).FullName;
+        var messageName = typeof(T).FullName!;
         NewRelic.Api.Agent.NewRelic.SetTransactionName("Message", messageName);
         try
         {

--- a/src/KnightBus.Newtonsoft/KnightBus.Newtonsoft.csproj
+++ b/src/KnightBus.Newtonsoft/KnightBus.Newtonsoft.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Json.Net serialization for KnightBus</Description>
-    <Version>5.1.0$(VersionSuffix)</Version>
+    <Version>5.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;json.net;newtonsoft</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/KnightBus.Newtonsoft/NewtonsoftSerializer.cs
+++ b/src/KnightBus.Newtonsoft/NewtonsoftSerializer.cs
@@ -29,7 +29,7 @@ public class NewtonsoftSerializer : IMessageSerializer
 
     public T Deserialize<T>(ReadOnlySpan<byte> serialized)
     {
-        return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(serialized), _settings);
+        return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(serialized), _settings)!;
     }
 
     public T Deserialize<T>(ReadOnlyMemory<byte> serialized)
@@ -37,7 +37,7 @@ public class NewtonsoftSerializer : IMessageSerializer
         return JsonConvert.DeserializeObject<T>(
             Encoding.UTF8.GetString(serialized.Span),
             _settings
-        );
+        )!;
     }
 
     public Task<T> Deserialize<T>(Stream serialized)
@@ -46,7 +46,7 @@ public class NewtonsoftSerializer : IMessageSerializer
 
         using var sr = new StreamReader(serialized);
         using var jsonTextReader = new JsonTextReader(sr);
-        return Task.FromResult(serializer.Deserialize<T>(jsonTextReader));
+        return Task.FromResult(serializer.Deserialize<T>(jsonTextReader)!);
     }
 
     public string ContentType => "application/json";

--- a/src/KnightBus.OpenTelemetry/KnightBus.OpenTelemetry.csproj
+++ b/src/KnightBus.OpenTelemetry/KnightBus.OpenTelemetry.csproj
@@ -6,7 +6,6 @@
     <Version>1.0.0-alpha3$(VersionSuffix)</Version>
     <PackageTags>knightbus;opentelemetry;tracing;observability</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/KnightBus.PostgreSql.Extensions.Azure/KnightBus.PostgreSql.Extensions.Azure.csproj
+++ b/src/KnightBus.PostgreSql.Extensions.Azure/KnightBus.PostgreSql.Extensions.Azure.csproj
@@ -6,7 +6,6 @@
     <Version>2.0.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/KnightBus.PostgreSql.Management.Extensions.Azure/KnightBus.PostgreSql.Management.Extensions.Azure.csproj
+++ b/src/KnightBus.PostgreSql.Management.Extensions.Azure/KnightBus.PostgreSql.Management.Extensions.Azure.csproj
@@ -6,7 +6,6 @@
     <Version>3.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/KnightBus.PostgreSql.Management/KnightBus.PostgreSql.Management.csproj
+++ b/src/KnightBus.PostgreSql.Management/KnightBus.PostgreSql.Management.csproj
@@ -6,7 +6,6 @@
     <Version>4.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/KnightBus.PostgreSql.Messages/KnightBus.PostgreSql.Messages.csproj
+++ b/src/KnightBus.PostgreSql.Messages/KnightBus.PostgreSql.Messages.csproj
@@ -6,7 +6,6 @@
     <Version>2.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/KnightBus.PostgreSql/CHANGELOG.md
+++ b/src/KnightBus.PostgreSql/CHANGELOG.md
@@ -1,5 +1,14 @@
 # KnightBus.PostgreSql Changelog
 
+# 4.1.0
+(minor): Nullable reference types are enabled repository-wide, so this package no longer sets
+`<Nullable>` itself. `PostgresConfiguration.ConnectionString` is now `string?` rather than
+`string = null!`, because `ITransportConfiguration` declares it nullable for the managed-identity
+transports and a get/set property's nullability is invariant. `UsePostgres` now throws
+`InvalidOperationException` when no connection string was configured, rather than passing null into
+`AddNpgsqlDataSource`, and `PostgresSubscriptionChannelReceiver` throws `ArgumentNullException`
+for a null subscription.
+
 # 2.3.0
 (minor): Allow passing a `Action<NpgsqlDataSourceBuilder>` to `UsePostgres` for custom configuration, for example Azure Managed Identity.
 

--- a/src/KnightBus.PostgreSql/KnightBus.PostgreSql.csproj
+++ b/src/KnightBus.PostgreSql/KnightBus.PostgreSql.csproj
@@ -6,7 +6,6 @@
     <Version>4.0.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/KnightBus.PostgreSql/KnightBus.PostgreSql.csproj
+++ b/src/KnightBus.PostgreSql/KnightBus.PostgreSql.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>PostgreSQL Transport for KnightBus</Description>
-    <Version>4.0.0$(VersionSuffix)</Version>
+    <Version>4.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/KnightBus.PostgreSql/PostgresChannelFactory.cs
+++ b/src/KnightBus.PostgreSql/PostgresChannelFactory.cs
@@ -24,7 +24,7 @@ public class PostgresChannelFactory : ITransportChannelFactory
 
     public IChannelReceiver Create(
         Type messageType,
-        IEventSubscription subscription,
+        IEventSubscription? subscription,
         IProcessingSettings processingSettings,
         IMessageSerializer serializer,
         IHostConfiguration configuration,

--- a/src/KnightBus.PostgreSql/PostgresChannelReceiver.cs
+++ b/src/KnightBus.PostgreSql/PostgresChannelReceiver.cs
@@ -8,7 +8,7 @@ namespace KnightBus.PostgreSql;
 public class PostgresChannelReceiver<T> : IChannelReceiver
     where T : class, IPostgresCommand
 {
-    private PostgresQueueClient<T> _queueClient;
+    private PostgresQueueClient<T> _queueClient = null!;
     private readonly NpgsqlDataSource _npgsqlDataSource;
     private readonly IMessageProcessor _processor;
     private readonly IHostConfiguration _hostConfiguration;

--- a/src/KnightBus.PostgreSql/PostgresConfiguration.cs
+++ b/src/KnightBus.PostgreSql/PostgresConfiguration.cs
@@ -18,7 +18,7 @@ public class PostgresConfiguration : IPostgresConfiguration
 
     public PostgresConfiguration() { }
 
-    public string ConnectionString { get; set; } = null!;
+    public string? ConnectionString { get; set; }
     public IMessageSerializer MessageSerializer { get; set; } = new MicrosoftJsonSerializer();
     public TimeSpan PollingDelay { get; set; } = TimeSpan.FromSeconds(5);
 }

--- a/src/KnightBus.PostgreSql/PostgresExtensions.cs
+++ b/src/KnightBus.PostgreSql/PostgresExtensions.cs
@@ -18,7 +18,8 @@ public static class PostgresExtensions
         services.AddSingleton<IPostgresConfiguration>(_ => postgresConfiguration);
 
         services.AddNpgsqlDataSource(
-            postgresConfiguration.ConnectionString,
+            postgresConfiguration.ConnectionString
+                ?? throw new InvalidOperationException("ConnectionString must be configured"),
             dataSourceBuilder ?? (_ => { }),
             serviceKey: PostgresConstants.NpgsqlDataSourceContainerKey
         );

--- a/src/KnightBus.PostgreSql/PostgresSubscriptionChannelFactory.cs
+++ b/src/KnightBus.PostgreSql/PostgresSubscriptionChannelFactory.cs
@@ -24,7 +24,7 @@ public class PostgresSubscriptionChannelFactory : ITransportChannelFactory
 
     public IChannelReceiver Create(
         Type messageType,
-        IEventSubscription subscription,
+        IEventSubscription? subscription,
         IProcessingSettings processingSettings,
         IMessageSerializer serializer,
         IHostConfiguration configuration,

--- a/src/KnightBus.PostgreSql/PostgresSubscriptionChannelReceiver.cs
+++ b/src/KnightBus.PostgreSql/PostgresSubscriptionChannelReceiver.cs
@@ -8,10 +8,10 @@ namespace KnightBus.PostgreSql;
 public class PostgresSubscriptionChannelReceiver<T> : IChannelReceiver
     where T : class, IPostgresEvent
 {
-    private PostgresSubscriptionClient<T> _queueClient;
+    private PostgresSubscriptionClient<T> _queueClient = null!;
     private readonly NpgsqlDataSource _npgsqlDataSource;
     private readonly IMessageProcessor _processor;
-    private readonly IEventSubscription? _subscription;
+    private readonly IEventSubscription _subscription;
     private readonly IHostConfiguration _hostConfiguration;
     private readonly IMessageSerializer _serializer;
     private readonly IPostgresConfiguration _postgresConfiguration;
@@ -28,7 +28,7 @@ public class PostgresSubscriptionChannelReceiver<T> : IChannelReceiver
     {
         _npgsqlDataSource = npgsqlDataSource;
         _processor = processor;
-        _subscription = subscription;
+        _subscription = subscription ?? throw new ArgumentNullException(nameof(subscription));
         Settings = settings;
         _hostConfiguration = hostConfiguration;
         _serializer = serializer;

--- a/src/KnightBus.Redis.Management/KnightBus.Redis.Management.csproj
+++ b/src/KnightBus.Redis.Management/KnightBus.Redis.Management.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Redis Transport Management for KnightBus</Description>
-    <Version>3.1.0$(VersionSuffix)</Version>
+    <Version>3.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;redis;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/src/KnightBus.Redis/KnightBus.Redis.csproj
+++ b/src/KnightBus.Redis/KnightBus.Redis.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Redis Transport for KnightBus</Description>
-    <Version>17.0.0$(VersionSuffix)</Version>
+    <Version>17.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;redis;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/src/KnightBus.Redis/LostMessageBackgroundService.cs
+++ b/src/KnightBus.Redis/LostMessageBackgroundService.cs
@@ -75,14 +75,16 @@ internal class LostMessageBackgroundService<T>
                 Debug.WriteLine($"Found {listItems.Length} processing in {queueName}");
 
                 var checkedItems = await Task.WhenAll(
-                        listItems.Select(item => HandlePotentiallyLostMessage(queueName, item))
+                        listItems.Select(item =>
+                            HandlePotentiallyLostMessage(queueName, ((byte[])item)!)
+                        )
                     )
                     .ConfigureAwait(false);
 
                 foreach (var (lost, message, listItem) in checkedItems.Where(item => item.lost))
                 {
                     if (
-                        await RecoverLostMessageAsync(queueName, listItem, message.Id)
+                        await RecoverLostMessageAsync(queueName, listItem, message!.Id)
                             .ConfigureAwait(false)
                     )
                     {
@@ -106,7 +108,7 @@ internal class LostMessageBackgroundService<T>
 
     private async Task<(
         bool lost,
-        RedisListItem<T> message,
+        RedisListItem<T>? message,
         RedisValue listItem
     )> HandlePotentiallyLostMessage(string queueName, byte[] listItem)
     {

--- a/src/KnightBus.Redis/RedisBus.cs
+++ b/src/KnightBus.Redis/RedisBus.cs
@@ -121,7 +121,7 @@ public class RedisBus : IRedisBus
                 subscriptions.Select(sub =>
                     SendAsync(
                         message,
-                        RedisQueueConventions.GetSubscriptionQueueName(queueName, sub)
+                        RedisQueueConventions.GetSubscriptionQueueName(queueName, ((string)sub)!)
                     )
                 )
             )
@@ -142,7 +142,7 @@ public class RedisBus : IRedisBus
                 subscriptions.Select(sub =>
                     SendAsync(
                         messageList,
-                        RedisQueueConventions.GetSubscriptionQueueName(queueName, sub)
+                        RedisQueueConventions.GetSubscriptionQueueName(queueName, ((string)sub)!)
                     )
                 )
             )

--- a/src/KnightBus.Redis/RedisCommandChannelFactory.cs
+++ b/src/KnightBus.Redis/RedisCommandChannelFactory.cs
@@ -23,7 +23,7 @@ internal class RedisCommandChannelFactory : ITransportChannelFactory
 
     public IChannelReceiver Create(
         Type messageType,
-        IEventSubscription subscription,
+        IEventSubscription? subscription,
         IProcessingSettings processingSettings,
         IMessageSerializer serializer,
         IHostConfiguration configuration,
@@ -31,7 +31,7 @@ internal class RedisCommandChannelFactory : ITransportChannelFactory
     )
     {
         var queueReaderType = typeof(RedisCommandChannelReceiver<>).MakeGenericType(messageType);
-        var queueReader = (IChannelReceiver)
+        var queueReader =
             Activator.CreateInstance(
                 queueReaderType,
                 _connectionMultiplexer,
@@ -40,8 +40,9 @@ internal class RedisCommandChannelFactory : ITransportChannelFactory
                 Configuration,
                 configuration,
                 processor
-            );
-        return queueReader;
+            ) as IChannelReceiver;
+        return queueReader
+            ?? throw new InvalidOperationException("ChannelReceiver could not be created");
     }
 
     public bool CanCreate(Type messageType)

--- a/src/KnightBus.Redis/RedisConfiguration.cs
+++ b/src/KnightBus.Redis/RedisConfiguration.cs
@@ -18,7 +18,7 @@ public class RedisConfiguration : IRedisConfiguration
         ConnectionString = connectionString;
     }
 
-    public string ConnectionString { get; set; }
+    public string? ConnectionString { get; set; }
     public IMessageSerializer MessageSerializer { get; set; } = new NewtonsoftSerializer();
     public int DatabaseId { get; set; }
 }

--- a/src/KnightBus.Redis/RedisDeadletter.cs
+++ b/src/KnightBus.Redis/RedisDeadletter.cs
@@ -7,9 +7,9 @@ namespace KnightBus.Redis;
 public class RedisDeadletter<T>
     where T : IMessage
 {
-    public RedisListItem<T> Message { get; internal set; }
+    public RedisListItem<T> Message { get; internal set; } = null!;
 
-    public IDictionary<string, string> HashEntries { get; internal set; }
+    public IDictionary<string, string> HashEntries { get; internal set; } = null!;
 
     public DateTimeOffset LastProcessed =>
         HashEntries.TryGetValue(RedisHashKeys.LastProcessed, out var value)

--- a/src/KnightBus.Redis/RedisEventChannelFactory.cs
+++ b/src/KnightBus.Redis/RedisEventChannelFactory.cs
@@ -23,7 +23,7 @@ internal class RedisEventChannelFactory : ITransportChannelFactory
 
     public IChannelReceiver Create(
         Type messageType,
-        IEventSubscription subscription,
+        IEventSubscription? subscription,
         IProcessingSettings processingSettings,
         IMessageSerializer serializer,
         IHostConfiguration configuration,
@@ -31,7 +31,7 @@ internal class RedisEventChannelFactory : ITransportChannelFactory
     )
     {
         var queueReaderType = typeof(RedisEventChannelReceiver<>).MakeGenericType(messageType);
-        var queueReader = (IChannelReceiver)
+        var queueReader =
             Activator.CreateInstance(
                 queueReaderType,
                 _connectionMultiplexer,
@@ -41,8 +41,9 @@ internal class RedisEventChannelFactory : ITransportChannelFactory
                 Configuration,
                 configuration,
                 processor
-            );
-        return queueReader;
+            ) as IChannelReceiver;
+        return queueReader
+            ?? throw new InvalidOperationException("ChannelReceiver could not be created");
     }
 
     public bool CanCreate(Type messageType)

--- a/src/KnightBus.Redis/RedisExtensions.cs
+++ b/src/KnightBus.Redis/RedisExtensions.cs
@@ -9,7 +9,7 @@ public static class RedisExtensions
 {
     public static IServiceCollection UseRedis(
         this IServiceCollection services,
-        Action<IRedisConfiguration> configuration = null
+        Action<IRedisConfiguration>? configuration = null
     )
     {
         var redisConfiguration = new RedisConfiguration();
@@ -18,6 +18,7 @@ public static class RedisExtensions
         services.AddSingleton<IConnectionMultiplexer>(provider =>
             ConnectionMultiplexer.Connect(
                 provider.GetRequiredService<IRedisConfiguration>().ConnectionString
+                    ?? throw new InvalidOperationException("ConnectionString must be configured")
             )
         );
         services.AddScoped<IRedisBus, RedisBus>();

--- a/src/KnightBus.Redis/RedisManagementClient.cs
+++ b/src/KnightBus.Redis/RedisManagementClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using KnightBus.Messages;
@@ -42,7 +43,10 @@ public class RedisManagementClient : IRedisManagementClient
     {
         _log = log;
         _db = ConnectionMultiplexer
-            .Connect(configuration.ConnectionString)
+            .Connect(
+                configuration.ConnectionString
+                    ?? throw new InvalidOperationException("ConnectionString must be configured")
+            )
             .GetDatabase(configuration.DatabaseId);
         _serializer = configuration.MessageSerializer;
     }

--- a/src/KnightBus.Redis/RedisMessagePump.cs
+++ b/src/KnightBus.Redis/RedisMessagePump.cs
@@ -16,9 +16,9 @@ internal class RedisMessagePump<T> : GenericMessagePump<RedisMessage<T>, IMessag
     private readonly string _queueName;
     private readonly IMessageSerializer _serializer;
     private readonly RedisConfiguration _redisConfiguration;
-    private RedisQueueClient<T> _queueClient;
-    private LostMessageBackgroundService<T> _lostMessageService;
-    private Task _lostMessageTask;
+    private RedisQueueClient<T> _queueClient = null!;
+    private LostMessageBackgroundService<T>? _lostMessageService;
+    private Task? _lostMessageTask;
 
     public RedisMessagePump(
         IConnectionMultiplexer connectionMultiplexer,
@@ -69,7 +69,7 @@ internal class RedisMessagePump<T> : GenericMessagePump<RedisMessage<T>, IMessag
         CancelPollingDelay();
     }
 
-    protected override async IAsyncEnumerable<RedisMessage<T>> GetMessagesAsync<TMessage>(
+    protected override async IAsyncEnumerable<RedisMessage<T>?> GetMessagesAsync<TMessage>(
         int count,
         TimeSpan? lockDuration
     )

--- a/src/KnightBus.Redis/RedisQueueClient.cs
+++ b/src/KnightBus.Redis/RedisQueueClient.cs
@@ -34,7 +34,7 @@ internal class RedisQueueClient<T>
         _log = log;
     }
 
-    internal async Task<RedisMessage<T>[]> GetMessagesAsync(int count)
+    internal async Task<RedisMessage<T>?[]> GetMessagesAsync(int count)
     {
         var queueMessageCount = await GetMessageCount(_queueName).ConfigureAwait(false);
 
@@ -55,14 +55,16 @@ internal class RedisQueueClient<T>
         return messages;
     }
 
-    private async Task<RedisMessage<T>> GetMessageAsync(CancellationTokenSource cancellationsSource)
+    private async Task<RedisMessage<T>?> GetMessageAsync(
+        CancellationTokenSource cancellationsSource
+    )
     {
         if (cancellationsSource.IsCancellationRequested)
             return null;
 
         try
         {
-            byte[] listItem = await _db.ListRightPopLeftPushAsync(
+            byte[]? listItem = await _db.ListRightPopLeftPushAsync(
                     _queueName,
                     RedisQueueConventions.GetProcessingQueueName(_queueName)
                 )
@@ -109,7 +111,7 @@ internal class RedisQueueClient<T>
             deadLetterQueueName
         );
 
-        byte[] listItem = await _db.ListRightPopLeftPushAsync(
+        byte[]? listItem = await _db.ListRightPopLeftPushAsync(
                 deadLetterQueueName,
                 deadLetterProcessingQueueName
             )
@@ -197,12 +199,12 @@ internal class RedisQueueClient<T>
 
         var values = await _db.ListRangeAsync(_queueName, 0, limit).ConfigureAwait(false);
 
-        foreach (byte[] value in values)
+        foreach (byte[]? value in values)
         {
-            var message = _serializer.Deserialize<RedisListItem<T>>(value.AsSpan());
+            var message = _serializer.Deserialize<RedisListItem<T>>(value!.AsSpan());
             var hashKey = RedisQueueConventions.GetMessageHashKey(_queueName, message.Id);
             var hash = await _db.HashGetAllAsync(hashKey).ConfigureAwait(false);
-            yield return new RedisMessage<T>(value, message.Id, message.Body, hash, _queueName);
+            yield return new RedisMessage<T>(value!, message.Id, message.Body, hash, _queueName);
         }
     }
 
@@ -218,11 +220,11 @@ internal class RedisQueueClient<T>
             )
             .ConfigureAwait(false);
 
-        foreach (byte[] value in values)
+        foreach (byte[]? value in values)
         {
             var deadletter = new RedisDeadletter<T>
             {
-                Message = _serializer.Deserialize<RedisListItem<T>>(value.AsSpan()),
+                Message = _serializer.Deserialize<RedisListItem<T>>(value!.AsSpan()),
             };
             var hash = RedisQueueConventions.GetMessageHashKey(_queueName, deadletter.Message.Id);
             var hashes = await _db.HashGetAllAsync(hash).ConfigureAwait(false);
@@ -239,11 +241,11 @@ internal class RedisQueueClient<T>
             )
             .ConfigureAwait(false);
 
-        foreach (byte[] value in values)
+        foreach (byte[]? value in values)
         {
             var deadLetter = new RedisDeadletter<T>
             {
-                Message = _serializer.Deserialize<RedisListItem<T>>(value.AsSpan()),
+                Message = _serializer.Deserialize<RedisListItem<T>>(value!.AsSpan()),
             };
             var hash = RedisQueueConventions.GetMessageHashKey(_queueName, deadLetter.Message.Id);
             var hashes = await _db.HashGetAllAsync(hash).ConfigureAwait(false);
@@ -287,11 +289,11 @@ internal class RedisQueueClient<T>
         // ReSharper disable once ConditionIsAlwaysTrueOrFalse
         if (values == null)
             return;
-        foreach (byte[] value in values)
+        foreach (byte[]? value in values)
         {
             var message = new RedisDeadletter<T>
             {
-                Message = _serializer.Deserialize<RedisListItem<T>>(value.AsSpan()),
+                Message = _serializer.Deserialize<RedisListItem<T>>(value!.AsSpan()),
             };
             await _db.KeyDeleteAsync(
                     RedisQueueConventions.GetMessageHashKey(_queueName, message.Message.Id)

--- a/src/KnightBus.Redis/RedisTransport.cs
+++ b/src/KnightBus.Redis/RedisTransport.cs
@@ -1,4 +1,5 @@
-﻿using KnightBus.Core;
+﻿using System;
+using KnightBus.Core;
 using StackExchange.Redis;
 
 namespace KnightBus.Redis;
@@ -10,7 +11,10 @@ public class RedisTransport : ITransport
 
     public RedisTransport(IRedisConfiguration configuration)
     {
-        var multiplexer = ConnectionMultiplexer.Connect(configuration.ConnectionString);
+        var multiplexer = ConnectionMultiplexer.Connect(
+            configuration.ConnectionString
+                ?? throw new InvalidOperationException("ConnectionString must be configured")
+        );
         TransportChannelFactories = new ITransportChannelFactory[]
         {
             new RedisCommandChannelFactory(configuration, multiplexer),

--- a/src/KnightBus.Schedule/CustomJobFactory.cs
+++ b/src/KnightBus.Schedule/CustomJobFactory.cs
@@ -24,7 +24,7 @@ public class CustomJobFactory : SimpleJobFactory
     {
         var jobType = typeof(JobExecutor<,>).MakeGenericType(settingsType, processorType);
         var jobExecutor = (IJob)
-            Activator.CreateInstance(jobType, log, singletonLockManager, dependencyInjection);
+            Activator.CreateInstance(jobType, log, singletonLockManager, dependencyInjection)!;
         _jobs.TryAdd(jobExecutor.GetType(), jobExecutor);
     }
 

--- a/src/KnightBus.Schedule/KnightBus.Schedule.csproj
+++ b/src/KnightBus.Schedule/KnightBus.Schedule.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>KnightBus Chron Scheduler</Description>
-    <Version>15.1.0$(VersionSuffix)</Version>
+    <Version>15.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;quartz;schedule;trigger</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/KnightBus.Schedule/SchedulingPlugin.cs
+++ b/src/KnightBus.Schedule/SchedulingPlugin.cs
@@ -14,7 +14,7 @@ public class SchedulingPlugin : IStoppablePlugin
 {
     private readonly IHostConfiguration _configuration;
     private readonly ILogger<SchedulingPlugin> _logger;
-    private IScheduler _scheduler;
+    private IScheduler? _scheduler;
 
     public SchedulingPlugin(IHostConfiguration configuration, ILogger<SchedulingPlugin> logger)
     {
@@ -56,7 +56,7 @@ public class SchedulingPlugin : IStoppablePlugin
                     processor.Name,
                     scheduleType.Name
                 );
-                var settings = (ISchedule)Activator.CreateInstance(scheduleType);
+                var settings = (ISchedule)Activator.CreateInstance(scheduleType)!;
 
                 CronExpression.ValidateExpression(settings.CronExpression);
 

--- a/src/KnightBus.SqlServer/KnightBus.SqlServer.csproj
+++ b/src/KnightBus.SqlServer/KnightBus.SqlServer.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Sql Server for KnightBus</Description>
-    <Version>17.0.0$(VersionSuffix)</Version>
+    <Version>17.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;sql;sql server;saga;</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/KnightBus.SqlServer/SqlServerSagaStore.cs
+++ b/src/KnightBus.SqlServer/SqlServerSagaStore.cs
@@ -78,7 +78,7 @@ public class SqlServerSagaStore : ISagaStore
 
                 await result.ReadAsync().ConfigureAwait(false);
                 var json = result.GetString(0);
-                return new SagaData<T> { Data = JsonSerializer.Deserialize<T>(json) };
+                return new SagaData<T> { Data = JsonSerializer.Deserialize<T>(json)! };
             }
             catch (SqlException e) when (e.Number == 208)
             {

--- a/tests/KnightBus.Azure.Storage.Tests.Integration/BlobLockManagerTests.cs
+++ b/tests/KnightBus.Azure.Storage.Tests.Integration/BlobLockManagerTests.cs
@@ -78,7 +78,7 @@ public class BlobLockManagerTests
             CancellationToken.None
         );
         //act
-        await handle.ReleaseAsync(CancellationToken.None);
+        await handle!.ReleaseAsync(CancellationToken.None);
         var secondHandle = await lockManager.TryLockAsync(
             lockId,
             TimeSpan.FromMinutes(1),
@@ -106,7 +106,7 @@ public class BlobLockManagerTests
         );
         //act
         await Task.Delay(TimeSpan.FromSeconds(10));
-        var renewed = await handle.RenewAsync(Mock.Of<ILogger>(), CancellationToken.None);
+        var renewed = await handle!.RenewAsync(Mock.Of<ILogger>(), CancellationToken.None);
         //assert
         renewed.Should().BeTrue();
     }
@@ -131,7 +131,7 @@ public class BlobLockManagerTests
         await Task.Delay(TimeSpan.FromSeconds(16));
         //steal lock
         await lockManager.TryLockAsync(lockId, TimeSpan.FromSeconds(15), CancellationToken.None);
-        await handle
+        await handle!
             .Awaiting(x => x.RenewAsync(Mock.Of<ILogger>(), CancellationToken.None))
             .Should()
             .ThrowAsync<RequestFailedException>();

--- a/tests/KnightBus.Azure.Storage.Tests.Integration/BlobStorageMessageAttachmentProviderTests.cs
+++ b/tests/KnightBus.Azure.Storage.Tests.Integration/BlobStorageMessageAttachmentProviderTests.cs
@@ -15,7 +15,7 @@ namespace KnightBus.Azure.Storage.Tests.Integration;
 
 public class BlobStorageMessageAttachmentProviderTests
 {
-    private BlobStorageMessageAttachmentProvider _target;
+    private BlobStorageMessageAttachmentProvider _target = null!;
 
     [SetUp]
     public void Setup()
@@ -45,7 +45,7 @@ public class BlobStorageMessageAttachmentProviderTests
         var id = await _target.UploadAttachmentAsync("queue", attachment);
 
         // Assert
-        var result = await _target.GetAttachmentAsync("queue", id);
+        var result = (await _target.GetAttachmentAsync("queue", id))!;
         result
             .Metadata.Should()
             .BeEquivalentTo(
@@ -78,7 +78,7 @@ public class BlobStorageMessageAttachmentProviderTests
         }
 
         // Act
-        var result = await provider.GetAttachmentAsync("dispose-test", id);
+        var result = (await provider.GetAttachmentAsync("dispose-test", id))!;
 
         // Assert - compressed attachments decompress on the fly and are read-forward only
         result.Stream.CanRead.Should().BeTrue();
@@ -129,7 +129,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await provider.UploadAttachmentAsync("compression-test", attachment);
-        var result = await provider.GetAttachmentAsync("compression-test", id);
+        var result = (await provider.GetAttachmentAsync("compression-test", id))!;
 
         // Assert
         using var reader = new StreamReader(result.Stream);
@@ -158,7 +158,7 @@ public class BlobStorageMessageAttachmentProviderTests
             new StorageBusConfiguration(StorageSetup.ConnectionString),
             new BlobStorageAttachmentOptions { EnableCompression = true }
         );
-        var result = await providerWithCompression.GetAttachmentAsync("compat-test", id);
+        var result = (await providerWithCompression.GetAttachmentAsync("compat-test", id))!;
 
         // Assert
         using var reader = new StreamReader(result.Stream);
@@ -186,7 +186,7 @@ public class BlobStorageMessageAttachmentProviderTests
         var providerNoCompression = new BlobStorageMessageAttachmentProvider(
             StorageSetup.ConnectionString
         );
-        var result = await providerNoCompression.GetAttachmentAsync("compat-test-2", id);
+        var result = (await providerNoCompression.GetAttachmentAsync("compat-test-2", id))!;
 
         // Assert
         using var reader = new StreamReader(result.Stream);
@@ -210,7 +210,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await provider.UploadAttachmentAsync("large-test", attachment);
-        var result = await provider.GetAttachmentAsync("large-test", id);
+        var result = (await provider.GetAttachmentAsync("large-test", id))!;
 
         // Assert - large enough to overflow the single-request threshold into staged blocks
         using var downloaded = new MemoryStream();
@@ -264,7 +264,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await provider.UploadAttachmentAsync("length-test", attachment);
-        var result = await provider.GetAttachmentAsync("length-test", id);
+        var result = (await provider.GetAttachmentAsync("length-test", id))!;
 
         // Assert - the decompressing stream cannot report a length, so it comes from metadata
         result.Length.Should().Be(originalContent.Length);
@@ -287,7 +287,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await provider.UploadAttachmentAsync("length-test", attachment);
-        var result = await provider.GetAttachmentAsync("length-test", id);
+        var result = (await provider.GetAttachmentAsync("length-test", id))!;
 
         // Assert
         using var downloaded = new MemoryStream();
@@ -314,7 +314,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await provider.UploadAttachmentAsync("length-test", attachment);
-        var result = await provider.GetAttachmentAsync("length-test", id);
+        var result = (await provider.GetAttachmentAsync("length-test", id))!;
 
         // Assert - 0 is the documented Length for non-seekable streams
         using var downloaded = new MemoryStream();
@@ -372,7 +372,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await provider.UploadAttachmentAsync("meta-test", attachment);
-        var result = await provider.GetAttachmentAsync("meta-test", id);
+        var result = (await provider.GetAttachmentAsync("meta-test", id))!;
 
         // Assert - the surface must not depend on whether compression is enabled
         result
@@ -443,7 +443,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await _target.UploadAttachmentAsync("collide-test", attachment);
-        var result = await _target.GetAttachmentAsync("collide-test", id);
+        var result = (await _target.GetAttachmentAsync("collide-test", id))!;
 
         // Assert
         result
@@ -487,7 +487,7 @@ public class BlobStorageMessageAttachmentProviderTests
         );
 
         // Assert
-        var result = await provider.GetAttachmentAsync(containerName, id);
+        var result = (await provider.GetAttachmentAsync(containerName, id))!;
         using var reader = new StreamReader(result.Stream);
         (await reader.ReadToEndAsync()).Should().Be("second");
     }

--- a/tests/KnightBus.Azure.Storage.Tests.Integration/BlobStorageMessageAttachmentProviderTests.cs
+++ b/tests/KnightBus.Azure.Storage.Tests.Integration/BlobStorageMessageAttachmentProviderTests.cs
@@ -45,7 +45,7 @@ public class BlobStorageMessageAttachmentProviderTests
         var id = await _target.UploadAttachmentAsync("queue", attachment);
 
         // Assert
-        var result = (await _target.GetAttachmentAsync("queue", id))!;
+        var result = await _target.GetAttachmentAsync("queue", id);
         result
             .Metadata.Should()
             .BeEquivalentTo(
@@ -78,7 +78,7 @@ public class BlobStorageMessageAttachmentProviderTests
         }
 
         // Act
-        var result = (await provider.GetAttachmentAsync("dispose-test", id))!;
+        var result = await provider.GetAttachmentAsync("dispose-test", id);
 
         // Assert - compressed attachments decompress on the fly and are read-forward only
         result.Stream.CanRead.Should().BeTrue();
@@ -129,7 +129,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await provider.UploadAttachmentAsync("compression-test", attachment);
-        var result = (await provider.GetAttachmentAsync("compression-test", id))!;
+        var result = await provider.GetAttachmentAsync("compression-test", id);
 
         // Assert
         using var reader = new StreamReader(result.Stream);
@@ -158,7 +158,7 @@ public class BlobStorageMessageAttachmentProviderTests
             new StorageBusConfiguration(StorageSetup.ConnectionString),
             new BlobStorageAttachmentOptions { EnableCompression = true }
         );
-        var result = (await providerWithCompression.GetAttachmentAsync("compat-test", id))!;
+        var result = await providerWithCompression.GetAttachmentAsync("compat-test", id);
 
         // Assert
         using var reader = new StreamReader(result.Stream);
@@ -186,7 +186,7 @@ public class BlobStorageMessageAttachmentProviderTests
         var providerNoCompression = new BlobStorageMessageAttachmentProvider(
             StorageSetup.ConnectionString
         );
-        var result = (await providerNoCompression.GetAttachmentAsync("compat-test-2", id))!;
+        var result = await providerNoCompression.GetAttachmentAsync("compat-test-2", id);
 
         // Assert
         using var reader = new StreamReader(result.Stream);
@@ -210,7 +210,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await provider.UploadAttachmentAsync("large-test", attachment);
-        var result = (await provider.GetAttachmentAsync("large-test", id))!;
+        var result = await provider.GetAttachmentAsync("large-test", id);
 
         // Assert - large enough to overflow the single-request threshold into staged blocks
         using var downloaded = new MemoryStream();
@@ -264,7 +264,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await provider.UploadAttachmentAsync("length-test", attachment);
-        var result = (await provider.GetAttachmentAsync("length-test", id))!;
+        var result = await provider.GetAttachmentAsync("length-test", id);
 
         // Assert - the decompressing stream cannot report a length, so it comes from metadata
         result.Length.Should().Be(originalContent.Length);
@@ -287,7 +287,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await provider.UploadAttachmentAsync("length-test", attachment);
-        var result = (await provider.GetAttachmentAsync("length-test", id))!;
+        var result = await provider.GetAttachmentAsync("length-test", id);
 
         // Assert
         using var downloaded = new MemoryStream();
@@ -314,7 +314,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await provider.UploadAttachmentAsync("length-test", attachment);
-        var result = (await provider.GetAttachmentAsync("length-test", id))!;
+        var result = await provider.GetAttachmentAsync("length-test", id);
 
         // Assert - 0 is the documented Length for non-seekable streams
         using var downloaded = new MemoryStream();
@@ -372,7 +372,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await provider.UploadAttachmentAsync("meta-test", attachment);
-        var result = (await provider.GetAttachmentAsync("meta-test", id))!;
+        var result = await provider.GetAttachmentAsync("meta-test", id);
 
         // Assert - the surface must not depend on whether compression is enabled
         result
@@ -443,7 +443,7 @@ public class BlobStorageMessageAttachmentProviderTests
 
         // Act
         var id = await _target.UploadAttachmentAsync("collide-test", attachment);
-        var result = (await _target.GetAttachmentAsync("collide-test", id))!;
+        var result = await _target.GetAttachmentAsync("collide-test", id);
 
         // Assert
         result

--- a/tests/KnightBus.Azure.Storage.Tests.Integration/BlobStorageMessageAttachmentProviderTests.cs
+++ b/tests/KnightBus.Azure.Storage.Tests.Integration/BlobStorageMessageAttachmentProviderTests.cs
@@ -487,7 +487,7 @@ public class BlobStorageMessageAttachmentProviderTests
         );
 
         // Assert
-        var result = (await provider.GetAttachmentAsync(containerName, id))!;
+        var result = await provider.GetAttachmentAsync(containerName, id);
         using var reader = new StreamReader(result.Stream);
         (await reader.ReadToEndAsync()).Should().Be("second");
     }

--- a/tests/KnightBus.Azure.Storage.Tests.Integration/StorageQueueManagerTests.cs
+++ b/tests/KnightBus.Azure.Storage.Tests.Integration/StorageQueueManagerTests.cs
@@ -71,6 +71,6 @@ public class StorageQueueManagerTests : QueueManagerTests<TestCommand>
             AutoMessageMapper.GetQueueName<TestCommand>()
         );
         var message = await client.GetMessagesAsync<TestCommand>(1, TimeSpan.FromSeconds(5));
-        return new StorageQueueMessageStateHandler<TestCommand>(client, message.First(), 5, null);
+        return new StorageQueueMessageStateHandler<TestCommand>(client, message.First(), 5, null!);
     }
 }

--- a/tests/KnightBus.Azure.Storage.Tests.Integration/StorageQueueMessagePumpTests.cs
+++ b/tests/KnightBus.Azure.Storage.Tests.Integration/StorageQueueMessagePumpTests.cs
@@ -14,8 +14,8 @@ namespace KnightBus.Azure.Storage.Tests.Integration;
 
 public class StorageQueueMessagePumpTests
 {
-    private StorageQueueClient _storageQueueClient;
-    private StorageQueueMessagePump _pump;
+    private StorageQueueClient _storageQueueClient = null!;
+    private StorageQueueMessagePump _pump = null!;
 
     [SetUp]
     public void SetUp()
@@ -70,5 +70,5 @@ public class TestCommandMessageMapping : IMessageMapping<TestCommand>
 
 public class TestCommand : IStorageQueueCommand
 {
-    public string Message { get; set; }
+    public string Message { get; set; } = null!;
 }

--- a/tests/KnightBus.Azure.Storage.Tests.Integration/StorageQueueMessageStateHandlerTests.cs
+++ b/tests/KnightBus.Azure.Storage.Tests.Integration/StorageQueueMessageStateHandlerTests.cs
@@ -80,6 +80,6 @@ public class StorageQueueMessageStateHandlerTests : MessageStateHandlerTests<Tes
             AutoMessageMapper.GetQueueName<TestCommand>()
         );
         var message = await client.GetMessagesAsync<TestCommand>(1, TimeSpan.FromSeconds(5));
-        return new StorageQueueMessageStateHandler<TestCommand>(client, message.First(), 5, null);
+        return new StorageQueueMessageStateHandler<TestCommand>(client, message.First(), 5, null!);
     }
 }

--- a/tests/KnightBus.Azure.Storage.Tests.Integration/StorageSetup.cs
+++ b/tests/KnightBus.Azure.Storage.Tests.Integration/StorageSetup.cs
@@ -10,7 +10,7 @@ internal class StorageSetup
     private static readonly AzuriteContainer Azurite = new AzuriteBuilder()
         .WithCommand("--skipApiVersionCheck")
         .Build();
-    public static string ConnectionString;
+    public static string ConnectionString = null!;
 
     [OneTimeSetUp]
     public async Task OneTimeSetUp()

--- a/tests/KnightBus.Azure.Storage.Tests.Unit/ExtendMessageLockDurationMiddlewareTests.cs
+++ b/tests/KnightBus.Azure.Storage.Tests.Unit/ExtendMessageLockDurationMiddlewareTests.cs
@@ -14,7 +14,7 @@ namespace KnightBus.Azure.Storage.Tests.Unit;
 [TestFixture]
 public class ExtendMessageLockDurationMiddlewareTests
 {
-    private Mock<IDependencyInjection> _dependencyInjection;
+    private Mock<IDependencyInjection> _dependencyInjection = null!;
 
     [Test]
     public async Task Should_allow_regular_processing_settings_to_bypass_the_renewal()
@@ -242,10 +242,10 @@ public class MyMessage : IStorageQueueCommand { }
 
 public class MyPipeline : IPipelineInformation
 {
-    public Type ProcessorInterfaceType { get; }
-    public IEventSubscription Subscription { get; }
-    public IProcessingSettings ProcessingSettings { get; set; }
-    public IHostConfiguration HostConfiguration { get; set; }
+    public Type ProcessorInterfaceType { get; } = null!;
+    public IEventSubscription? Subscription { get; }
+    public IProcessingSettings ProcessingSettings { get; set; } = null!;
+    public IHostConfiguration HostConfiguration { get; set; } = null!;
 }
 
 public class MySettings : IProcessingSettings, IExtendMessageLockTimeout

--- a/tests/KnightBus.Azure.Storage.Tests.Unit/LongRunningTestCommand.cs
+++ b/tests/KnightBus.Azure.Storage.Tests.Unit/LongRunningTestCommand.cs
@@ -7,7 +7,7 @@ namespace KnightBus.Azure.Storage.Tests.Unit;
 
 public class LongRunningTestCommand : IStorageQueueCommand
 {
-    public string Message { get; set; }
+    public string Message { get; set; } = null!;
 }
 
 public class LongRunningTestMessageMapping : IMessageMapping<LongRunningTestCommand>

--- a/tests/KnightBus.Azure.Storage.Tests.Unit/StorageQueueMessagePumpTests.cs
+++ b/tests/KnightBus.Azure.Storage.Tests.Unit/StorageQueueMessagePumpTests.cs
@@ -13,7 +13,7 @@ namespace KnightBus.Azure.Storage.Tests.Unit;
 [TestFixture]
 public class StorageQueueMessagePumpTests
 {
-    private Mock<IStorageQueueClient> _clientMock;
+    private Mock<IStorageQueueClient> _clientMock = null!;
 
     [SetUp]
     public void SetUp()

--- a/tests/KnightBus.Core.Tests.Unit/AttachmentCommand.cs
+++ b/tests/KnightBus.Core.Tests.Unit/AttachmentCommand.cs
@@ -4,9 +4,9 @@ namespace KnightBus.Core.Tests.Unit;
 
 public class AttachmentCommand : ICommandWithAttachment, ICommand
 {
-    public string Message { get; set; }
-    public string MessageId { get; set; }
-    public IMessageAttachment Attachment { get; set; }
+    public string Message { get; set; } = null!;
+    public string MessageId { get; set; } = null!;
+    public IMessageAttachment? Attachment { get; set; }
 }
 
 public class AttachmentCommandMapping : IMessageMapping<AttachmentCommand>

--- a/tests/KnightBus.Core.Tests.Unit/AttachmentMiddlewareTests.cs
+++ b/tests/KnightBus.Core.Tests.Unit/AttachmentMiddlewareTests.cs
@@ -251,7 +251,7 @@ public class AttachmentMiddlewareTests
                     It.IsAny<CancellationToken>()
                 )
             )
-            .ReturnsAsync(default(IMessageAttachment));
+            .ReturnsAsync(default(IMessageAttachment)!);
         var middleware = new AttachmentMiddleware(attachmentProvider.Object);
         //act
         await middleware.ProcessAsync(

--- a/tests/KnightBus.Core.Tests.Unit/AttachmentMiddlewareTests.cs
+++ b/tests/KnightBus.Core.Tests.Unit/AttachmentMiddlewareTests.cs
@@ -54,7 +54,7 @@ public class AttachmentMiddlewareTests
         );
         //assert
         stream.CanRead.Should().BeFalse("It should have been disposed");
-        message.Attachment.Filename.Should().Be("test.txt");
+        message.Attachment!.Filename.Should().Be("test.txt");
         message.Attachment.ContentType.Should().Be("text/plain");
         nextProcessor.Verify(
             x => x.ProcessAsync(stateHandler.Object, CancellationToken.None),
@@ -216,7 +216,7 @@ public class AttachmentMiddlewareTests
                     It.IsAny<EventId>(),
                     It.Is<It.IsAnyType>((v, t) => true),
                     It.IsAny<Exception>(),
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
                 ),
             Times.Once,
             "the orphaned attachment must be visible in the log"

--- a/tests/KnightBus.Core.Tests.Unit/AutoMessageMapperTests.cs
+++ b/tests/KnightBus.Core.Tests.Unit/AutoMessageMapperTests.cs
@@ -33,12 +33,12 @@ public class AutoMessageMapperTests
 
 public class NotRegisteredMessage : ICommand
 {
-    public string MessageId { get; set; }
+    public string MessageId { get; set; } = null!;
 }
 
 public class RegisteredCommand : ICommand
 {
-    public string MessageId { get; set; }
+    public string MessageId { get; set; } = null!;
 }
 
 public class RegisteredMessageMapping : IMessageMapping<RegisteredCommand>

--- a/tests/KnightBus.Core.Tests.Unit/ErrorHandlingMiddlewareTests.cs
+++ b/tests/KnightBus.Core.Tests.Unit/ErrorHandlingMiddlewareTests.cs
@@ -63,10 +63,10 @@ public class ErrorHandlingMiddlewareTests
                     It.Is<EventId>(eventId => eventId.Id == 0),
                     It.Is<It.IsAnyType>(
                         (@object, @type) =>
-                            @object.ToString().StartsWith("Error processing message")
+                            @object.ToString()!.StartsWith("Error processing message")
                     ),
                     It.IsAny<Exception>(),
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
                 ),
             Times.Once
         );
@@ -128,10 +128,10 @@ public class ErrorHandlingMiddlewareTests
                     It.Is<EventId>(eventId => eventId.Id == 0),
                     It.Is<It.IsAnyType>(
                         (@object, @type) =>
-                            @object.ToString().StartsWith("Failed to abandon message")
+                            @object.ToString()!.StartsWith("Failed to abandon message")
                     ),
                     It.IsAny<Exception>(),
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
                 ),
             Times.Once
         );

--- a/tests/KnightBus.Core.Tests.Unit/GenericMessagePumpTests.cs
+++ b/tests/KnightBus.Core.Tests.Unit/GenericMessagePumpTests.cs
@@ -28,11 +28,12 @@ public class GenericMessagePumpTests
     {
         public readonly ConcurrentQueue<(
             LogLevel Level,
-            Exception Exception,
+            Exception? Exception,
             string Message
         )> Entries = new();
 
-        public IDisposable BeginScope<TState>(TState state) => null;
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
 
         public bool IsEnabled(LogLevel logLevel) => true;
 
@@ -40,8 +41,8 @@ public class GenericMessagePumpTests
             LogLevel logLevel,
             EventId eventId,
             TState state,
-            Exception exception,
-            Func<TState, Exception, string> formatter
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
         )
         {
             Entries.Enqueue((logLevel, exception, formatter(state, exception)));
@@ -50,8 +51,8 @@ public class GenericMessagePumpTests
 
     private class TestMessagePump : GenericMessagePump<TestCommand, ICommand>
     {
-        private readonly Func<Task> _createChannel;
-        private readonly Func<Task> _cleanupResources;
+        private readonly Func<Task>? _createChannel;
+        private readonly Func<Task>? _cleanupResources;
         private readonly TimeSpan? _pollingDelay;
         private int _getMessagesInvocations;
         private int _createChannelInvocations;
@@ -64,8 +65,8 @@ public class GenericMessagePumpTests
 
         public TestMessagePump(
             ILogger log,
-            Func<Task> createChannel = null,
-            Func<Task> cleanupResources = null,
+            Func<Task>? createChannel = null,
+            Func<Task>? cleanupResources = null,
             TimeSpan? pollingDelay = null
         )
             : base(new TestPumpSettings(), log)

--- a/tests/KnightBus.Core.Tests.Unit/JsonSerializerTests.cs
+++ b/tests/KnightBus.Core.Tests.Unit/JsonSerializerTests.cs
@@ -88,7 +88,7 @@ public class JsonSerializerTests
 
     public class TestSerializationCommand : ICommand
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public int Age { get; set; }
         public float Height { get; set; }
     }

--- a/tests/KnightBus.Core.Tests.Unit/MessageMapperTests.cs
+++ b/tests/KnightBus.Core.Tests.Unit/MessageMapperTests.cs
@@ -64,7 +64,7 @@ public class MessageMapperTests
 
 public class MessageMapperRegisteredCommand : ICommand
 {
-    public string MessageId { get; set; }
+    public string MessageId { get; set; } = null!;
 }
 
 public class MessageMapperRegisteredCommandMapping : IMessageMapping<MessageMapperRegisteredCommand>

--- a/tests/KnightBus.Core.Tests.Unit/MicrosoftDependencyInjectionTests.cs
+++ b/tests/KnightBus.Core.Tests.Unit/MicrosoftDependencyInjectionTests.cs
@@ -12,7 +12,7 @@ namespace KnightBus.Core.Tests.Unit;
 
 public class TestSchedule : ISchedule
 {
-    public string CronExpression { get; }
+    public string CronExpression { get; } = null!;
     public TimeZoneInfo TimeZone => TimeZoneInfo.Utc;
 }
 
@@ -26,7 +26,7 @@ public class TestScheduleProcessor : IProcessSchedule<TestSchedule>
 
 public class MicrosoftDependencyInjectionTests
 {
-    private MicrosoftDependencyInjection DependencyInjection { get; set; }
+    private MicrosoftDependencyInjection DependencyInjection { get; set; } = null!;
 
     [SetUp]
     public void Setup()

--- a/tests/KnightBus.Core.Tests.Unit/SagaMapperTests.cs
+++ b/tests/KnightBus.Core.Tests.Unit/SagaMapperTests.cs
@@ -50,7 +50,7 @@ public class SagaMapperTests
 
     internal class TestMessage : IMessage
     {
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
     }
 
     internal class UnMappedMessage : IMessage { }

--- a/tests/KnightBus.Core.Tests.Unit/SagaMiddlewareTests.cs
+++ b/tests/KnightBus.Core.Tests.Unit/SagaMiddlewareTests.cs
@@ -54,7 +54,7 @@ public class SagaMiddlewareTests
         await middleware.ProcessAsync(
             messageStateHandler.Object,
             pipelineInformation.Object,
-            null,
+            null!,
             CancellationToken.None
         );
         //assert
@@ -102,7 +102,7 @@ public class SagaMiddlewareTests
         await middleware.ProcessAsync(
             messageStateHandler.Object,
             pipelineInformation.Object,
-            null,
+            null!,
             CancellationToken.None
         );
         //assert
@@ -153,7 +153,7 @@ public class SagaMiddlewareTests
                 x.ProcessAsync(
                     messageStateHandler.Object,
                     pipelineInformation.Object,
-                    null,
+                    null!,
                     CancellationToken.None
                 )
             )
@@ -333,7 +333,7 @@ public class SagaMiddlewareTests
 
     public class SagaData
     {
-        public string Data { get; set; }
+        public string Data { get; set; } = null!;
     }
 
     public class SagaStartMessage : ICommand { }

--- a/tests/KnightBus.Host.Tests.Unit/MessageProcessorLocatorTests.cs
+++ b/tests/KnightBus.Host.Tests.Unit/MessageProcessorLocatorTests.cs
@@ -18,7 +18,7 @@ namespace KnightBus.Host.Tests.Unit;
 [TestFixture]
 public class MessageProcessorLocatorTests
 {
-    private Mock<ITransportChannelFactory> _queueStarterFactory;
+    private Mock<ITransportChannelFactory> _queueStarterFactory = null!;
 
     [SetUp]
     public void Setup()

--- a/tests/KnightBus.Host.Tests.Unit/Middleware/MiddlewarePipeLineTest.cs
+++ b/tests/KnightBus.Host.Tests.Unit/Middleware/MiddlewarePipeLineTest.cs
@@ -204,7 +204,7 @@ public class MiddlewarePipelineTest
     {
         public int DeliveryCount { get; }
         public int DeadLetterDeliveryLimit { get; }
-        public IDictionary<string, string> MessageProperties { get; }
+        public IDictionary<string, string> MessageProperties { get; } = null!;
 
         public Task CompleteAsync()
         {
@@ -231,6 +231,6 @@ public class MiddlewarePipelineTest
             throw new NotImplementedException();
         }
 
-        public IDependencyInjection MessageScope { get; set; }
+        public IDependencyInjection MessageScope { get; set; } = null!;
     }
 }

--- a/tests/KnightBus.Host.Tests.Unit/SingletonChannelReceiverTests.cs
+++ b/tests/KnightBus.Host.Tests.Unit/SingletonChannelReceiverTests.cs
@@ -25,7 +25,7 @@ public class SingletonChannelReceiverTests
                 x.TryLockAsync(It.IsAny<string>(), TimeSpan.FromSeconds(60), CancellationToken.None)
             )
             .ReturnsAsync(Mock.Of<ISingletonLockHandle>())
-            .ReturnsAsync((ISingletonLockHandle)null);
+            .ReturnsAsync((ISingletonLockHandle?)null);
         var underlyingReceiver = new Mock<IChannelReceiver>();
         underlyingReceiver.Setup(x => x.Settings).Returns(new Mock<IProcessingSettings>().Object);
         var singletonChannelReceiver = new SingletonChannelReceiver(
@@ -54,7 +54,7 @@ public class SingletonChannelReceiverTests
                 x.TryLockAsync(It.IsAny<string>(), TimeSpan.FromSeconds(60), CancellationToken.None)
             )
             .ReturnsAsync(Mock.Of<ISingletonLockHandle>())
-            .ReturnsAsync((ISingletonLockHandle)null)
+            .ReturnsAsync((ISingletonLockHandle?)null)
             .ReturnsAsync(Mock.Of<ISingletonLockHandle>());
         var underlyingReceiver = new Mock<IChannelReceiver>();
         underlyingReceiver.Setup(x => x.Settings).Returns(new Mock<IProcessingSettings>().Object);

--- a/tests/KnightBus.Host.Tests.Unit/StandardMessagePipelineTests.cs
+++ b/tests/KnightBus.Host.Tests.Unit/StandardMessagePipelineTests.cs
@@ -15,13 +15,13 @@ namespace KnightBus.Host.Tests.Unit;
 [TestFixture]
 public class StandardMessagePipelineTests
 {
-    private IMessageProcessor _messageProcessor;
-    private Mock<IMessageStateHandler<TestCommandOne>> _stateHandler;
-    private Mock<ICountable> _countable;
-    private Mock<ILogger> _logger;
-    private Mock<IDependencyInjection> _messageHandlerProvider;
-    private Mock<IPipelineInformation> _pipelineInformation;
-    private Mock<IHostConfiguration> _hostConfiguration;
+    private IMessageProcessor _messageProcessor = null!;
+    private Mock<IMessageStateHandler<TestCommandOne>> _stateHandler = null!;
+    private Mock<ICountable> _countable = null!;
+    private Mock<ILogger> _logger = null!;
+    private Mock<IDependencyInjection> _messageHandlerProvider = null!;
+    private Mock<IPipelineInformation> _pipelineInformation = null!;
+    private Mock<IHostConfiguration> _hostConfiguration = null!;
 
     [SetUp]
     public void Setup()
@@ -115,10 +115,10 @@ public class StandardMessagePipelineTests
                     It.Is<EventId>(eventId => eventId.Id == 0),
                     It.Is<It.IsAnyType>(
                         (@object, @type) =>
-                            @object.ToString().StartsWith("Error processing message")
+                            @object.ToString()!.StartsWith("Error processing message")
                     ),
                     It.IsAny<Exception>(),
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
                 ),
             Times.Once
         );

--- a/tests/KnightBus.Host.Tests.Unit/TestMessages.cs
+++ b/tests/KnightBus.Host.Tests.Unit/TestMessages.cs
@@ -44,8 +44,8 @@ public class TestCommandTwo : ICommand { }
 
 public class AttachmentCommand : ICommandWithAttachment, ICommand
 {
-    public string Message { get; set; }
-    public IMessageAttachment Attachment { get; set; }
+    public string Message { get; set; } = null!;
+    public IMessageAttachment? Attachment { get; set; }
 }
 
 public class AttachmentMessageMapping : IMessageMapping<AttachmentCommand>

--- a/tests/KnightBus.PostgreSql.Tests.Integration/KnightBus.PostgreSql.Tests.Integration.csproj
+++ b/tests/KnightBus.PostgreSql.Tests.Integration/KnightBus.PostgreSql.Tests.Integration.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/KnightBus.PostgreSql.Tests.Integration/PostgresBusTests.cs
+++ b/tests/KnightBus.PostgreSql.Tests.Integration/PostgresBusTests.cs
@@ -581,7 +581,7 @@ WHERE message_id = {message[0].Id}"
 
 public class TestCommand : IPostgresCommand
 {
-    public string MessageBody { get; set; }
+    public string MessageBody { get; set; } = null!;
 }
 
 public class BusTestEvent : IPostgresEvent

--- a/tests/KnightBus.PostgreSql.Tests.Integration/PostgresMessageStateHandlerTests.cs
+++ b/tests/KnightBus.PostgreSql.Tests.Integration/PostgresMessageStateHandlerTests.cs
@@ -7,9 +7,9 @@ namespace KnightBus.PostgreSql.Tests.Integration;
 
 public class PostgresMessageStateHandlerTests : MessageStateHandlerTests<PostgresTestCommand>
 {
-    private PostgresBus _bus;
-    private PostgresQueueClient<PostgresTestCommand> _postgresQueueClient;
-    private PostgresManagementClient _postgresManagementClient;
+    private PostgresBus _bus = null!;
+    private PostgresQueueClient<PostgresTestCommand> _postgresQueueClient = null!;
+    private PostgresManagementClient _postgresManagementClient = null!;
 
     public override async Task Setup()
     {

--- a/tests/KnightBus.PostgreSql.Tests.Integration/PostgresQueueManagerTests.cs
+++ b/tests/KnightBus.PostgreSql.Tests.Integration/PostgresQueueManagerTests.cs
@@ -9,9 +9,9 @@ namespace KnightBus.PostgreSql.Tests.Integration;
 [TestFixture]
 public class PostgresQueueManagerTests : QueueManagerTests<PostgresTestCommand>
 {
-    private PostgresBus _bus;
-    private PostgresQueueClient<PostgresTestCommand> _postgresQueueClient;
-    private PostgresManagementClient _postgresManagementClient;
+    private PostgresBus _bus = null!;
+    private PostgresQueueClient<PostgresTestCommand> _postgresQueueClient = null!;
+    private PostgresManagementClient _postgresManagementClient = null!;
 
     public override async Task Setup()
     {

--- a/tests/KnightBus.PostgreSql.Tests.Integration/PostgresSetup.cs
+++ b/tests/KnightBus.PostgreSql.Tests.Integration/PostgresSetup.cs
@@ -14,8 +14,8 @@ public class PostgresSetup
         .WithPassword("passw")
         .Build();
 
-    public static NpgsqlDataSource DataSource;
-    public static string ConnectionString;
+    public static NpgsqlDataSource DataSource = null!;
+    public static string ConnectionString = null!;
 
     [OneTimeSetUp]
     public async Task OneTimeSetup()

--- a/tests/KnightBus.PostgreSql.Tests.Integration/PostgresSubscriptionManagerTests.cs
+++ b/tests/KnightBus.PostgreSql.Tests.Integration/PostgresSubscriptionManagerTests.cs
@@ -9,9 +9,9 @@ namespace KnightBus.PostgreSql.Tests.Integration;
 [TestFixture]
 public class PostgresSubscriptionManagerTests : QueueManagerTests<PostgresTestEvent>
 {
-    private PostgresBus _bus;
-    private PostgresSubscriptionClient<PostgresTestEvent> _postgresQueueClient;
-    private PostgresManagementClient _postgresManagementClient;
+    private PostgresBus _bus = null!;
+    private PostgresSubscriptionClient<PostgresTestEvent> _postgresQueueClient = null!;
+    private PostgresManagementClient _postgresManagementClient = null!;
     private readonly PostgresTestEventSubscription _eventSubscription = new();
 
     public override async Task Setup()

--- a/tests/KnightBus.PostgreSql.Tests.Integration/PostgresTopicManagerTests.cs
+++ b/tests/KnightBus.PostgreSql.Tests.Integration/PostgresTopicManagerTests.cs
@@ -8,9 +8,9 @@ namespace KnightBus.PostgreSql.Tests.Integration;
 [TestFixture]
 public class PostgresTopicManagerTests
 {
-    private PostgresManagementClient _postgresManagementClient;
+    private PostgresManagementClient _postgresManagementClient = null!;
     private readonly PostgresTestEventSubscription _eventSubscription = new();
-    private PostgresTopicManager _queueManager;
+    private PostgresTopicManager _queueManager = null!;
 
     [SetUp]
     public async Task Setup()

--- a/tests/KnightBus.Redis.Tests.Integration/RedisMessageStateHandlerTests.cs
+++ b/tests/KnightBus.Redis.Tests.Integration/RedisMessageStateHandlerTests.cs
@@ -16,12 +16,12 @@ namespace KnightBus.Redis.Tests.Integration;
 [TestFixture]
 public class RedisMessageStateHandlerTests : MessageStateHandlerTests<TestCommand>
 {
-    private RedisBus _bus;
+    private RedisBus _bus = null!;
 
     public override async Task Setup()
     {
         _bus = new RedisBus(
-            RedisTestBase.Configuration.ConnectionString,
+            RedisTestBase.Configuration.ConnectionString!,
             Array.Empty<IMessagePreProcessor>()
         );
         var logger = new Mock<ILogger<RedisManagementClient>>();
@@ -31,7 +31,7 @@ public class RedisMessageStateHandlerTests : MessageStateHandlerTests<TestComman
         );
         var qm = new RedisQueueManager(managementClient, RedisTestBase.Configuration);
         _bus = new RedisBus(
-            RedisTestBase.Configuration.ConnectionString,
+            RedisTestBase.Configuration.ConnectionString!,
             Array.Empty<IMessagePreProcessor>()
         );
         await qm.Delete(AutoMessageMapper.GetQueueName<TestCommand>(), CancellationToken.None);
@@ -82,9 +82,9 @@ public class RedisMessageStateHandlerTests : MessageStateHandlerTests<TestComman
         return new RedisMessageStateHandler<TestCommand>(
             RedisTestBase.Multiplexer,
             RedisTestBase.Configuration,
-            m.First(),
+            m.First()!,
             5,
-            null,
+            null!,
             Mock.Of<ILogger>()
         );
     }

--- a/tests/KnightBus.Redis.Tests.Integration/RedisQueueClientTests.cs
+++ b/tests/KnightBus.Redis.Tests.Integration/RedisQueueClientTests.cs
@@ -12,8 +12,8 @@ namespace KnightBus.Redis.Tests.Integration;
 
 public class RedisQueueClientTests
 {
-    private IRedisBus _bus;
-    private RedisQueueClient<TestCommand> _target;
+    private IRedisBus _bus = null!;
+    private RedisQueueClient<TestCommand> _target = null!;
     private ILogger _log = Mock.Of<ILogger>();
     private readonly string _queueName = AutoMessageMapper.GetQueueName<TestCommand>();
 
@@ -21,7 +21,7 @@ public class RedisQueueClientTests
     public void Setup()
     {
         _bus = new RedisBus(
-            RedisTestBase.Configuration.ConnectionString,
+            RedisTestBase.Configuration.ConnectionString!,
             Enumerable.Empty<IMessagePreProcessor>()
         );
         _target = new RedisQueueClient<TestCommand>(
@@ -36,7 +36,7 @@ public class RedisQueueClientTests
     public void BaseTeardown()
     {
         var server = RedisTestBase.Database.Multiplexer.GetServer(
-            RedisTestBase.Configuration.ConnectionString
+            RedisTestBase.Configuration.ConnectionString!
         );
         server.FlushDatabase();
     }
@@ -46,7 +46,7 @@ public class RedisQueueClientTests
         var command = new TestCommand(Guid.NewGuid().ToString());
         await _bus.SendAsync(command);
         var messages = await _target.GetMessagesAsync(1);
-        return messages.First();
+        return messages.First()!;
     }
 
     [Test]
@@ -67,7 +67,7 @@ public class RedisQueueClientTests
 
         //Assert
         messages.Length.Should().Be(1);
-        var message = messages.First();
+        var message = messages.First()!;
         message.Message.Should().BeEquivalentTo(command);
         message.HashEntries.Should().ContainKey(RedisHashKeys.DeliveryCount);
         message.HashEntries.Should().ContainKey(RedisHashKeys.LastProcessed);
@@ -118,7 +118,7 @@ public class RedisQueueClientTests
         errorMessage.Should().Be(exception.Message);
 
         var reQueuedMessages = await _target.GetMessagesAsync(1);
-        var reQueuedMessage = reQueuedMessages.First();
+        var reQueuedMessage = reQueuedMessages.First()!;
         reQueuedMessage.Message.Should().BeEquivalentTo(message.Message);
         reQueuedMessage.HashKey.Should().BeEquivalentTo(message.HashKey);
     }

--- a/tests/KnightBus.Redis.Tests.Integration/RedisQueueManagerTests.cs
+++ b/tests/KnightBus.Redis.Tests.Integration/RedisQueueManagerTests.cs
@@ -17,7 +17,7 @@ namespace KnightBus.Redis.Tests.Integration;
 [TestFixture]
 public class RedisQueueManagerTests : QueueManagerTests<TestCommand>
 {
-    private RedisBus _bus;
+    private RedisBus _bus = null!;
 
     public override async Task Setup()
     {
@@ -25,7 +25,7 @@ public class RedisQueueManagerTests : QueueManagerTests<TestCommand>
         var managementClient = new RedisManagementClient(Configuration, logger.Object);
         QueueManager = new RedisQueueManager(managementClient, Configuration);
         QueueType = QueueType.Queue;
-        _bus = new RedisBus(Configuration.ConnectionString, Array.Empty<IMessagePreProcessor>());
+        _bus = new RedisBus(Configuration.ConnectionString!, Array.Empty<IMessagePreProcessor>());
         var queues = await QueueManager.List(CancellationToken.None);
         await QueueManager.Delete(
             AutoMessageMapper.GetQueueName<TestCommand>(),
@@ -66,9 +66,9 @@ public class RedisQueueManagerTests : QueueManagerTests<TestCommand>
         return new RedisMessageStateHandler<TestCommand>(
             Multiplexer,
             Configuration,
-            m.First(),
+            m.First()!,
             5,
-            null,
+            null!,
             Mock.Of<ILogger>()
         );
     }

--- a/tests/KnightBus.Redis.Tests.Integration/RedisSagaStoreTests.cs
+++ b/tests/KnightBus.Redis.Tests.Integration/RedisSagaStoreTests.cs
@@ -13,7 +13,7 @@ namespace KnightBus.Redis.Tests.Integration;
 [TestFixture]
 public class RedisSagaStoreTests : ConcurrentSagaStoreTests
 {
-    private IRedisConfiguration _configuration;
+    private IRedisConfiguration _configuration = null!;
 
     public override void Setup()
     {
@@ -131,7 +131,7 @@ public class RedisSagaStoreTests : ConcurrentSagaStoreTests
             .MessageSerializer.Deserialize<Data>((ReadOnlyMemory<byte>)fields[0])
             .Message.Should()
             .Be("yo");
-        ((string)fields[1]).Should().Be(created.ConcurrencyStamp);
+        ((string?)fields[1]).Should().Be(created.ConcurrencyStamp);
     }
 
     [Test]
@@ -305,7 +305,7 @@ public class RedisSagaStoreTests : ConcurrentSagaStoreTests
             .Should()
             .ThrowAsync<ArgumentException>();
         await SagaStore
-            .Awaiting(x => x.GetSaga<Data>("partition", null, CancellationToken.None))
+            .Awaiting(x => x.GetSaga<Data>("partition", null!, CancellationToken.None))
             .Should()
             .ThrowAsync<ArgumentException>();
     }

--- a/tests/KnightBus.Redis.Tests.Integration/RedisSetup.cs
+++ b/tests/KnightBus.Redis.Tests.Integration/RedisSetup.cs
@@ -12,7 +12,7 @@ public class RedisSetup
         .WithPortBinding(6380, 6379)
         .Build();
 
-    public static string ConnectionString;
+    public static string ConnectionString = null!;
 
     [OneTimeSetUp]
     public async Task OneTimeSetup()

--- a/tests/KnightBus.Redis.Tests.Integration/RedisTestBase.cs
+++ b/tests/KnightBus.Redis.Tests.Integration/RedisTestBase.cs
@@ -6,10 +6,10 @@ namespace KnightBus.Redis.Tests.Integration;
 [SetUpFixture]
 public sealed class RedisTestBase
 {
-    public static IRedisConfiguration Configuration;
-    public static IDatabase Database;
+    public static IRedisConfiguration Configuration = null!;
+    public static IDatabase Database = null!;
 
-    public static IConnectionMultiplexer Multiplexer;
+    public static IConnectionMultiplexer Multiplexer = null!;
 
     [OneTimeSetUp]
     public void BaseSetup()

--- a/tests/KnightBus.Redis.Tests.Unit/RedisQueueClientTests.cs
+++ b/tests/KnightBus.Redis.Tests.Unit/RedisQueueClientTests.cs
@@ -11,8 +11,8 @@ namespace KnightBus.Redis.Tests.Unit;
 [TestFixture]
 public class RedisQueueClientTests
 {
-    private Mock<IDatabase> _db;
-    private RedisQueueClient<TestCommand> _target;
+    private Mock<IDatabase> _db = null!;
+    private RedisQueueClient<TestCommand> _target = null!;
     private ILogger _log = Mock.Of<ILogger>();
 
     [SetUp]

--- a/tests/KnightBus.Schedule.Tests.Unit/JobExecutorTests.cs
+++ b/tests/KnightBus.Schedule.Tests.Unit/JobExecutorTests.cs
@@ -114,7 +114,7 @@ public class JobExecutorTests
                     It.IsAny<CancellationToken>()
                 )
             )
-            .ReturnsAsync((ISingletonLockHandle)null);
+            .ReturnsAsync((ISingletonLockHandle?)null);
         var processor = new Mock<IProcessSchedule<DummySchedule>>();
         var di = new Mock<IDependencyInjection>();
         di.Setup(x => x.GetScope()).Returns(di.Object);
@@ -132,7 +132,7 @@ public class JobExecutorTests
 
     public class DummySchedule : ISchedule
     {
-        public string CronExpression { get; }
+        public string CronExpression { get; } = null!;
         public TimeZoneInfo TimeZone => TimeZoneInfo.Utc;
     }
 }

--- a/tests/KnightBus.Schedule.Tests.Unit/ScheduleProcessorLockingTests.cs
+++ b/tests/KnightBus.Schedule.Tests.Unit/ScheduleProcessorLockingTests.cs
@@ -96,7 +96,7 @@ public class ScheduleProcessorLockingTests
     {
         private readonly ConcurrentDictionary<string, byte> _heldLocks = new();
 
-        public Task<ISingletonLockHandle> TryLockAsync(
+        public Task<ISingletonLockHandle?> TryLockAsync(
             string lockId,
             TimeSpan lockPeriod,
             CancellationToken cancellationToken
@@ -104,10 +104,10 @@ public class ScheduleProcessorLockingTests
         {
             if (_heldLocks.TryAdd(lockId, 0))
             {
-                return Task.FromResult<ISingletonLockHandle>(new TrackingLockHandle(lockId));
+                return Task.FromResult<ISingletonLockHandle?>(new TrackingLockHandle(lockId));
             }
 
-            return Task.FromResult<ISingletonLockHandle>(null);
+            return Task.FromResult<ISingletonLockHandle?>(null);
         }
 
         public Task InitializeAsync()

--- a/tests/KnightBus.Shared.Tests.Integration/ConcurrentSagaStoreTests.cs
+++ b/tests/KnightBus.Shared.Tests.Integration/ConcurrentSagaStoreTests.cs
@@ -280,7 +280,7 @@ public class ConcurrentSagaStoreTests : SagaStoreTests
         stored.ConcurrencyStamp.Should().Be(winner.ConcurrencyStamp);
     }
 
-    private async Task<SagaDataConflictException> TryUpdate(
+    private async Task<SagaDataConflictException?> TryUpdate(
         string partitionKey,
         string id,
         SagaData<Data> sagaData

--- a/tests/KnightBus.Shared.Tests.Integration/QueueManagerTests.cs
+++ b/tests/KnightBus.Shared.Tests.Integration/QueueManagerTests.cs
@@ -16,7 +16,7 @@ namespace KnightBus.Shared.Tests.Integration;
 public abstract class QueueManagerTests<TCommand>
     where TCommand : class, IMessage
 {
-    protected IQueueManager QueueManager { get; set; }
+    protected IQueueManager QueueManager { get; set; } = null!;
     protected QueueType QueueType { get; set; }
 
     [SetUp]

--- a/tests/KnightBus.Shared.Tests.Integration/SagaStoreTests.cs
+++ b/tests/KnightBus.Shared.Tests.Integration/SagaStoreTests.cs
@@ -11,11 +11,11 @@ namespace KnightBus.Shared.Tests.Integration;
 [TestFixture]
 public class SagaStoreTests
 {
-    protected ISagaStore SagaStore { get; set; }
+    protected ISagaStore SagaStore { get; set; } = null!;
 
     protected class Data
     {
-        public string Message { get; set; }
+        public string Message { get; set; } = null!;
     }
 
     [SetUp]

--- a/tests/KnightBus.SqlServer.Tests.Integration/SqlServerSetup.cs
+++ b/tests/KnightBus.SqlServer.Tests.Integration/SqlServerSetup.cs
@@ -14,7 +14,7 @@ public class SqlServerSetup
         .WithPortBinding(14333, 1433)
         .Build();
 
-    public static string ConnectionString;
+    public static string ConnectionString = null!;
 
     [OneTimeSetUp]
     public async Task OneTimeSetup()


### PR DESCRIPTION
Enables `<Nullable>enable</Nullable>` for all 45 projects via the root `Directory.Build.props` and adds `<WarningsAsErrors>$(WarningsAsErrors);Nullable</WarningsAsErrors>` so nullable warnings fail the build from now on. The 10 per-csproj `<Nullable>` lines and 2 `#nullable enable` directives became redundant and were removed.

The annotations are behavior-preserving on the public API surface — signatures only gain `?`/`!`/initializers. Key contract decisions, verified against actual null flows:

* `ICommandWithAttachment.Attachment` → `IMessageAttachment?` (null until `AttachmentMiddleware` re-hydrates it)
* `ITransportChannelFactory.Create` → `IEventSubscription? subscription` (null for command processors)
* `ITransportConfiguration.ConnectionString` → `string?` (blank when using managed identity)
* `ISingletonLockManager.TryLockAsync` → `Task<ISingletonLockHandle?>` (documented as returning null). `IMessageAttachmentProvider.GetAttachmentAsync` stays non-nullable: no implementation has ever returned null for a missing attachment — both the Blob provider and the removed Redis one throw
* `IMessageSerializer.Deserialize<T>` keeps non-nullable `T`; implementations use `!` so a `"null"` payload behaves exactly as before

Nullable-enabled consumers implementing these extension points will see new CS8767/CS8613 warnings until they match the annotations (see CHANGELOG). Merging publishes a minor bump for the **17 packages whose compiled surface changed** — every
package that was not already nullable-annotated. The other 9 are byte-for-byte identical and keep
their versions: the four PostgreSql satellites, `KnightBus.Nats.Messages` and
`KnightBus.OpenTelemetry` were already annotated, and `KnightBus.Azure.ServiceBus.Messages`,
`KnightBus.Azure.Storage.Messages` and `KnightBus.Redis.Messages` hold only marker interfaces with
nothing to annotate. The full version list is in `CHANGELOG.md`; `KnightBus.Core`,
`KnightBus.Azure.ServiceBus` and `KnightBus.PostgreSql` also have entries in their own changelogs.

Scope was verified rather than assumed: `dotnet pack` confirms the 17 versions and the dependency
floors between them, and compiling a nullable-enabled consumer against the before/after assemblies
confirmed that even the two Management packages with no source edits changed their public contract
(passing a `string?` connection string now warns CS8604 where it previously did not).

Found and fixed along the way (from an adversarial review pass, reproduced against Azurite):

* `BlobSagaStore.Create` discarded the recursive call's result on the container-not-found path and returned saga data with a null `ConcurrencyStamp`, silently disabling optimistic concurrency for the first saga in a fresh storage account
* A missing `ConnectionString` (Redis/Postgres) and a failed channel receiver construction now throw `InvalidOperationException` up front instead of failing obscurely inside the client libraries; `PostgresSubscriptionChannelReceiver` now throws `ArgumentNullException` for a null subscription

Every `?` was then audited against its actual null producers and consumers, and the ones that were merely defensive were reverted, so `?` in this diff means null is reachable:

* `QueueMessage.Error` stays non-nullable — all 16 construction sites coalesce to `string.Empty`
* `KnightBusHost._locator` was only ever assigned and read inside one block, so it is a local now and the nullable field is gone
* `ServiceBusChannelReceiverBase._client` and `BlobLockManager._client` are assigned during startup before any read and had no null check, so they use `= null!` and drop their suppressions
* The request processor factories read the generic argument directly rather than round-tripping through the nullable `ProcessorTypes`

Kept because null is provably reachable: `ICommandWithAttachment.Attachment` (`AttachmentPreProcessor` supports sending without an attachment, so receivers see null), `SagaData.ConcurrencyStamp` (`SqlServerSagaStore` never sets it), `ITransportConfiguration.ConnectionString` (managed identity for Storage/ServiceBus — and since the property has both accessors its nullability is invariant, which is what forces the `?? throw` sites in Redis/Postgres), plus `TryLockAsync`, `ReceiveDeadLetterAsync`, `GetMessagesAsync` and the private fields that have a real null state.

Docs updated to the new signatures (`attachments.md`, `marker-interfaces.md`, `singleton-processing.md`).

Verified: `dotnet build KnightBus.slnx --no-incremental` clean in Debug and Release on both TFMs (zero CS8xxx), `dotnet csharpier check` passes, and all 300 tests pass including the Testcontainers-based integration suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176nyGkxqpWKrvJAEpwYtnx


