### PR TITLE
chore(deps): sweep all centrally managed NuGet packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,43 @@
 * `PostgresMessageStateHandler` implements `IMessageLockHandler<T>`, so `ExtendMessageLockDurationMiddleware` renews message locks on this transport and `IExtendMessageLockTimeout` settings are now supported here. A renewal pushes `visibility_timeout` forward and only applies while the consumer still holds the row; once another consumer has fetched it, the renewal is a no-op
 * The fetch lock is passed to the queue client as a `TimeSpan` instead of whole seconds, so a fractional `MessageLockTimeout` or `ExtensionDuration` no longer truncates — a value under one second used to become a zero-second lock. `PostgresBaseClient.GetMessagesAsync` gained a `TimeSpan` overload; the `int` one remains
 
-# 2026-08-26
+### Dependency sweep
+Every centrally managed dependency moved to its current release. No API changed; what changed for
+consumers is the minimum version each package resolves against, so the twelve packages holding a
+direct reference to something that moved get a minor bump: `KnightBus.Core` 18.4.0, `KnightBus.Host`
+18.3.0, `KnightBus.Azure.ServiceBus` 24.2.0, `KnightBus.Azure.Storage` 18.3.0, `KnightBus.Redis`
+17.2.0, `KnightBus.SqlServer` 17.2.0, `KnightBus.PostgreSql` 4.3.0, `KnightBus.PostgreSql.Management`
+4.2.0, `KnightBus.PostgreSql.Extensions.Azure` 2.1.0, `KnightBus.Schedule` 15.3.0,
+`KnightBus.NewRelic` 13.2.0 and `KnightBus.OpenTelemetry` 1.0.0-alpha4.
+
+`KnightBus.PostgreSql` goes to 4.3.0 rather than 4.2.0: the lock-extension release above already
+published 4.2.0 with the previous Npgsql floor, and CI pushes with `--skip-duplicate`, so reusing
+that version would drop the new floor silently.
+
+The remaining fourteen packages are unchanged and not republished. `KnightBus.ApplicationInsights`,
+`KnightBus.Nats` and `KnightBus.Newtonsoft` were already on the current version of everything they
+reference; the `.Messages` and `.Management` satellites have no package references of their own, and
+the floors their published nuspecs already declare still resolve against the new versions.
+
+* Runtime packages, pinned per target framework: `Microsoft.Extensions.*` and `System.Text.Json` to
+  9.0.19 on `net9.0` and 10.0.11 on `net10.0`; `Npgsql` and `Npgsql.DependencyInjection` to 9.0.5 and
+  10.0.3
+* `Azure.Identity` 1.21.0, `Azure.Storage.Blobs` 12.29.2, `Azure.Storage.Queues` 12.27.1,
+  `Azure.Messaging.ServiceBus` 7.20.2, `Quartz` 3.19.1, `NewRelic.Agent.Api` 10.54.0 and the
+  OpenTelemetry family 1.18.0
+* **Held back deliberately.** `StackExchange.Redis` stays on 2.x (2.13.17): 3.x mirrors the 2.13.17
+  API, but it defaults to RESP3 and would raise the floor in `KnightBus.Redis`, forcing every
+  consumer off 2.x — that belongs in its own major release. `Microsoft.Data.SqlClient` stays on the
+  6.1 LTS line (6.1.6) rather than 7.0.2, which is short-term support. `FluentAssertions` keeps its
+  `[7.2.0,8.0.0)` range, the guard against the v8 licence change
+* `PostgresAzureConfiguration.TokenCredential` now defaults to
+  `new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned)`; Azure.Identity 1.21.0 obsoleted
+  the constructor the old default resolved to. Same system-assigned identity, spelled explicitly
+* Twelve security advisories against transitive test dependencies are gone — `MessagePack` 2.5.192
+  (two high, nine moderate) reached the build through `Microsoft.NET.Test.Sdk`, now 18.9.0, and
+  `SSH.NET` 2024.2.0 (one high) through Testcontainers, now 4.14.0. Both were confined to the test
+  suites and the Aspire sample, all of which are `IsPackable=false`, so no published package ever
+  carried them
 
 ### Nullable reference types enabled across all packages
 All public APIs now carry nullability annotations; the signatures themselves are unchanged. Released

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,19 +14,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
-    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.2" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.27.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.23.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.23.0" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
+    <!-- Held on the 6.1 LTS line; 7.x is STS, and this floor is what consumers inherit. -->
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.6" />
     <PackageVersion Include="NATS.Client" Version="1.1.8" />
-    <PackageVersion Include="NewRelic.Agent.Api" Version="10.47.0" />
+    <PackageVersion Include="NewRelic.Agent.Api" Version="10.54.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageVersion Include="Quartz" Version="3.15.1" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.10.1" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.18.0" />
+    <PackageVersion Include="Quartz" Version="3.19.1" />
+    <!--
+      Held on 2.x. The 3.x API mirrors 2.13.17, but it defaults to RESP3 and raises the floor
+      in the published KnightBus.Redis package, forcing consumers off 2.x — its own release.
+    -->
+    <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
   </ItemGroup>
 
   <!--
@@ -36,52 +41,54 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion
       Include="Microsoft.Extensions.DependencyInjection.Abstractions"
-      Version="9.0.3"
+      Version="9.0.19"
     />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
-    <PackageVersion Include="Npgsql" Version="9.0.4" />
-    <PackageVersion Include="Npgsql.DependencyInjection" Version="9.0.4" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.19" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.19" />
+    <PackageVersion Include="Npgsql" Version="9.0.5" />
+    <PackageVersion Include="Npgsql.DependencyInjection" Version="9.0.5" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.19" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
     <PackageVersion
       Include="Microsoft.Extensions.DependencyInjection.Abstractions"
-      Version="10.0.0"
+      Version="10.0.11"
     />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Npgsql" Version="10.0.1" />
-    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Npgsql" Version="10.0.3" />
+    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.11" />
   </ItemGroup>
 
   <!-- Test-only -->
   <ItemGroup>
-    <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.6.0" />
     <PackageVersion Include="FluentAssertions" Version="[7.2.0,8.0.0)" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="NUnit" Version="4.3.2" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageVersion Include="Testcontainers.Azurite" Version="4.3.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.3.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.3.0" />
-    <PackageVersion Include="Testcontainers.Redis" Version="4.3.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.3.0" />
+    <PackageVersion Include="Testcontainers.Azurite" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.14.0" />
   </ItemGroup>
 
   <!-- Sample-only -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.0.2" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <!-- Travels with Aspire.AppHost.Sdk, pinned in the AspireHost csproj. -->
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.5.3" />
+    <PackageVersion Include="OpenTelemetry" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
+    <!-- Has never shipped a stable release. -->
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.18.0-rc.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
   </ItemGroup>
 </Project>

--- a/samples/KnightBus.Samples.Azure.AspireHost/KnightBus.Samples.Azure.AspireHost.csproj
+++ b/samples/KnightBus.Samples.Azure.AspireHost/KnightBus.Samples.Azure.AspireHost.csproj
@@ -1,9 +1,14 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.0.2">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.3">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>b2ad9cab-ed30-4aba-b11f-df0144c0ee91</UserSecretsId>
+    <!--
+      Aspire 13.5 warns when the CLI bundle is absent. The sample only needs to build and run
+      locally, so it opts out rather than pulling the bundle into CI.
+    -->
+    <NoWarn>$(NoWarn);ASPIRE010</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../KnightBus.Samples.Azure.ServiceBus.Producer/KnightBus.Samples.Azure.ServiceBus.Producer.csproj" />

--- a/src/KnightBus.Azure.ServiceBus/CHANGELOG.md
+++ b/src/KnightBus.Azure.ServiceBus/CHANGELOG.md
@@ -1,5 +1,11 @@
 ﻿# KnightBus.Azure.ServiceBus Changelog
 
+## 24.2.0
+### Changed
+- `Azure.Identity` moves to 1.21.0 and `Azure.Messaging.ServiceBus` to 7.20.2, raising the floor
+  consumers resolve against. No API change
+
+
 ## 24.1.0
 ### Changed
 - Nullable reference types are enabled. `IServiceBusConfiguration.FullyQualifiedNamespace` and

--- a/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
+++ b/src/KnightBus.Azure.ServiceBus/KnightBus.Azure.ServiceBus.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Azure Service Bus Transport for KnightBus</Description>
-    <Version>24.1.0$(VersionSuffix)</Version>
+    <Version>24.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;azure servicebus;amqp;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/src/KnightBus.Azure.Storage/KnightBus.Azure.Storage.csproj
+++ b/src/KnightBus.Azure.Storage/KnightBus.Azure.Storage.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Azure Storage Transport for KnightBus</Description>
-    <Version>18.2.0$(VersionSuffix)</Version>
+    <Version>18.3.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;azure storage;blob;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/src/KnightBus.Core/CHANGELOG.md
+++ b/src/KnightBus.Core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # KnightBus.Core Changelog
 
+# 18.4.0
+* `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`
+  and `System.Text.Json` move to 9.0.19 on `net9.0` and 10.0.11 on `net10.0`, raising the floor
+  consumers resolve against. No API change
+
 # 18.3.0
 * Nullable reference types are enabled. Public APIs carry nullability annotations; no signature changed.
   Implementations of the annotated extension points get new warnings until they match:

--- a/src/KnightBus.Core/KnightBus.Core.csproj
+++ b/src/KnightBus.Core/KnightBus.Core.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Shared core functionallity for the KnightBus framework</Description>
-    <Version>18.3.0$(VersionSuffix)</Version>
+    <Version>18.4.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/KnightBus.Host/KnightBus.Host.csproj
+++ b/src/KnightBus.Host/KnightBus.Host.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>KnightBus Host</Description>
-    <Version>18.2.0$(VersionSuffix)</Version>
+    <Version>18.3.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;servicebus;esb;queues;messaging</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/KnightBus.NewRelic/KnightBus.NewRelic.csproj
+++ b/src/KnightBus.NewRelic/KnightBus.NewRelic.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>KnightBus.NewRelicMiddleware</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>NewRelic.Agent.Api for KnightBus</Description>
-    <Version>13.1.0$(VersionSuffix)</Version>
+    <Version>13.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;apm;newrelic.agent.api</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/KnightBus.OpenTelemetry/KnightBus.OpenTelemetry.csproj
+++ b/src/KnightBus.OpenTelemetry/KnightBus.OpenTelemetry.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>OpenTelemetry for KnightBus</Description>
-    <Version>1.0.0-alpha3$(VersionSuffix)</Version>
+    <Version>1.0.0-alpha4$(VersionSuffix)</Version>
     <PackageTags>knightbus;opentelemetry;tracing;observability</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/KnightBus.PostgreSql.Extensions.Azure/KnightBus.PostgreSql.Extensions.Azure.csproj
+++ b/src/KnightBus.PostgreSql.Extensions.Azure/KnightBus.PostgreSql.Extensions.Azure.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Extension methods for setting up the KnightBus PostgreSql transport in Azure</Description>
-    <Version>2.0.0$(VersionSuffix)</Version>
+    <Version>2.1.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/KnightBus.PostgreSql.Extensions.Azure/PostgresAzureConfiguration.cs
+++ b/src/KnightBus.PostgreSql.Extensions.Azure/PostgresAzureConfiguration.cs
@@ -27,7 +27,8 @@ public class PostgresAzureConfiguration : PostgresConfiguration
     /// <summary>
     /// <see cref="TokenCredential"/> to use for acquiring Azure AD tokens. Defaults to <see cref="ManagedIdentityCredential"/>
     /// </summary>
-    public TokenCredential TokenCredential { get; set; } = new ManagedIdentityCredential();
+    public TokenCredential TokenCredential { get; set; } =
+        new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned);
 
     /// <summary>
     /// The set of scopes to request when acquiring an Azure AD token.

--- a/src/KnightBus.PostgreSql.Management/KnightBus.PostgreSql.Management.csproj
+++ b/src/KnightBus.PostgreSql.Management/KnightBus.PostgreSql.Management.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>PostgreSQL Transport Management for KnightBus</Description>
-    <Version>4.1.0$(VersionSuffix)</Version>
+    <Version>4.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/KnightBus.PostgreSql/CHANGELOG.md
+++ b/src/KnightBus.PostgreSql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # KnightBus.PostgreSql Changelog
 
+# 4.3.0
+(minor): `Npgsql` and `Npgsql.DependencyInjection` move to 9.0.5 on `net9.0` and 10.0.3 on `net10.0`,
+raising the floor consumers resolve against. No API change.
+
 # 4.2.0
 (minor): Implement `IMessageLockHandler<T>` on `PostgresMessageStateHandler` so `ExtendMessageLockDurationMiddleware` can renew message locks. The fetch lock is passed as a `TimeSpan`, so fractional durations no longer truncate to whole seconds.
 

--- a/src/KnightBus.PostgreSql/KnightBus.PostgreSql.csproj
+++ b/src/KnightBus.PostgreSql/KnightBus.PostgreSql.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>PostgreSQL Transport for KnightBus</Description>
-    <Version>4.2.0$(VersionSuffix)</Version>
+    <Version>4.3.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;postgresql;queues;messaging</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/KnightBus.Redis/KnightBus.Redis.csproj
+++ b/src/KnightBus.Redis/KnightBus.Redis.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Redis Transport for KnightBus</Description>
-    <Version>17.1.0$(VersionSuffix)</Version>
+    <Version>17.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;redis;queues;messaging</PackageTags>
   </PropertyGroup>
 

--- a/src/KnightBus.Schedule/KnightBus.Schedule.csproj
+++ b/src/KnightBus.Schedule/KnightBus.Schedule.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>KnightBus Chron Scheduler</Description>
-    <Version>15.2.0$(VersionSuffix)</Version>
+    <Version>15.3.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;quartz;schedule;trigger</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/KnightBus.SqlServer/KnightBus.SqlServer.csproj
+++ b/src/KnightBus.SqlServer/KnightBus.SqlServer.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Sql Server for KnightBus</Description>
-    <Version>17.1.0$(VersionSuffix)</Version>
+    <Version>17.2.0$(VersionSuffix)</Version>
     <PackageTags>knightbus;sql;sql server;saga;</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/KnightBus.Azure.Storage.Tests.Integration/StorageSetup.cs
+++ b/tests/KnightBus.Azure.Storage.Tests.Integration/StorageSetup.cs
@@ -7,7 +7,10 @@ namespace KnightBus.Azure.Storage.Tests.Integration;
 [SetUpFixture]
 internal class StorageSetup
 {
-    private static readonly AzuriteContainer Azurite = new AzuriteBuilder()
+    // The image was the module default until Testcontainers made it explicit; keeping the same tag.
+    private static readonly AzuriteContainer Azurite = new AzuriteBuilder(
+        "mcr.microsoft.com/azure-storage/azurite:3.28.0"
+    )
         .WithCommand("--skipApiVersionCheck")
         .Build();
     public static string ConnectionString = null!;

--- a/tests/KnightBus.PostgreSql.Tests.Integration/PostgresSetup.cs
+++ b/tests/KnightBus.PostgreSql.Tests.Integration/PostgresSetup.cs
@@ -7,8 +7,7 @@ namespace KnightBus.PostgreSql.Tests.Integration;
 [SetUpFixture]
 public class PostgresSetup
 {
-    private static readonly PostgreSqlContainer Postgres = new PostgreSqlBuilder()
-        .WithImage("postgres")
+    private static readonly PostgreSqlContainer Postgres = new PostgreSqlBuilder("postgres")
         .WithPortBinding(5433, 5432)
         .WithUsername("postgres")
         .WithPassword("passw")

--- a/tests/KnightBus.Redis.Tests.Integration/RedisSetup.cs
+++ b/tests/KnightBus.Redis.Tests.Integration/RedisSetup.cs
@@ -7,8 +7,7 @@ namespace KnightBus.Redis.Tests.Integration;
 [SetUpFixture]
 public class RedisSetup
 {
-    private static readonly RedisContainer Redis = new RedisBuilder()
-        .WithImage("redis")
+    private static readonly RedisContainer Redis = new RedisBuilder("redis")
         .WithPortBinding(6380, 6379)
         .Build();
 

--- a/tests/KnightBus.SqlServer.Tests.Integration/SqlServerSetup.cs
+++ b/tests/KnightBus.SqlServer.Tests.Integration/SqlServerSetup.cs
@@ -10,7 +10,10 @@ public class SqlServerSetup
 {
     private const string DatabaseName = "KnightBus";
 
-    private static readonly IDatabaseContainer MsSql = new MsSqlBuilder()
+    // The image was the module default until Testcontainers made it explicit; keeping the same tag.
+    private static readonly IDatabaseContainer MsSql = new MsSqlBuilder(
+        "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04"
+    )
         .WithPortBinding(14333, 1433)
         .Build();
 


### PR DESCRIPTION
## What this changes

Brings every dependency in `Directory.Packages.props` to its current release in one pass, instead of the trickle of near-identical grouped Dependabot PRs. `Aspire.AppHost.Sdk` is pinned in the AspireHost csproj rather than centrally, so it does not move on its own and is bumped here alongside `Aspire.Hosting.Azure.ServiceBus`.

Twelve packages hold a direct reference to something that moved, so their published dependency floor changes and they get a minor bump: `KnightBus.Core` 18.4.0, `KnightBus.Host` 18.3.0, `KnightBus.Azure.ServiceBus` 24.2.0, `KnightBus.Azure.Storage` 18.3.0, `KnightBus.Redis` 17.2.0, `KnightBus.SqlServer` 17.2.0, `KnightBus.PostgreSql` 4.3.0, `KnightBus.PostgreSql.Management` 4.2.0, `KnightBus.PostgreSql.Extensions.Azure` 2.1.0, `KnightBus.Schedule` 15.3.0, `KnightBus.NewRelic` 13.2.0, `KnightBus.OpenTelemetry` 1.0.0-alpha4.

The other fourteen are unchanged and not republished — `KnightBus.ApplicationInsights`, `KnightBus.Nats` and `KnightBus.Newtonsoft` were already current on everything they reference, and the satellites have no package references of their own.

**This clears twelve NuGet Audit advisories.** `MessagePack` 2.5.192 (two high, nine moderate) reached the build through `Microsoft.NET.Test.Sdk`, and `SSH.NET` 2024.2.0 (one high) through Testcontainers. `master` builds with 60 NU1902/NU1903 warnings; this branch builds with none. Both were confined to the test suites and the Aspire sample, all `IsPackable=false`, so no published package ever carried them.

## Notes for the reviewer

**Three versions are held back deliberately**, and each carries a comment in `Directory.Packages.props` so the next Dependabot PR does not quietly undo it:

- `StackExchange.Redis` stays on 2.x (2.13.17 — latest 2.x). 3.x is compile-compatible on paper, and the code uses the `new RedisChannel(name, PatternMode.Literal)` *constructor* rather than the conversion operators obsoleted in 2.6.116. But 3.x defaults to RESP3 and raises the floor in the published `KnightBus.Redis`, forcing every consumer off 2.x. That belongs in its own major release. Worth a second opinion if you disagree.
- `Microsoft.Data.SqlClient` stays on the 6.1 LTS line (6.1.6, supported to 2028-08-14) rather than 7.0.2, which is STS and loses support three months after the next release ships.
- `FluentAssertions` keeps its `[7.2.0,8.0.0)` range — the v8 licence guard. 8.10.0 exists and must not be picked up.

**`KnightBus.PostgreSql` goes to 4.3.0, not 4.2.0.** #227 already published 4.2.0 with the previous Npgsql floor. CI pushes with `--skip-duplicate`, so reusing that version would have packed the new floor and then silently discarded it on publish — no failure, no moved floor. This is the one thing here worth double-checking.

**Five call sites needed real changes** for new obsoletions:

- `PostgresAzureConfiguration.TokenCredential` now defaults to `new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned)`. Azure.Identity 1.21.0 obsoleted the constructor the old parameterless call resolved to. Same system-assigned identity, spelled explicitly — this one is in a shipped package.
- The four Testcontainers setups pass their image to the builder constructor, since the parameterless overload is obsolete. Redis and Postgres already called `.WithImage(...)`, so those just moved. Azurite and MsSql relied on the module defaults, so those tags are now explicit — verified byte-identical between 4.3.0 and 4.14.0, so no behaviour change.

**Verification beyond the checklist.** `NUnit3TestAdapter` 5 → 6 is a major bump of the runner, where a mismatch shows up as tests silently not being discovered rather than as a build error. Test counts are identical per suite against a `master` baseline build, so nothing was dropped. I also inspected the packed nuspecs to confirm the floors moved as intended, including the per-TFM split — `KnightBus.Core` declares 9.0.19 for `net9.0` and 10.0.11 for `net10.0`.

**Two judgment calls, easy to reverse:**

- The Aspire 13.5 SDK emits a new `ASPIRE010` advisory about the missing CLI bundle. I suppressed it in the sample AppHost with `NoWarn` rather than pulling the bundle into CI. Say the word and I'll set `AspireUseCliBundle=true` instead.
- `csharpier` stays at 1.2.1 in `.config/dotnet-tools.json`; 1.3.0 is out, but a formatter bump can reflow files repo-wide and does not belong in this diff.

**Out of scope:** the 5 open Dependabot alerts are all pip packages in `docs/requirements.txt` (`pymdown-extensions`, `urllib3`, `requests`) — unrelated to this sweep, and that file is hash-pinned so it needs hashes regenerated rather than a version line edited. `NU1510` (`System.Text.Json` in `KnightBus.Core` now likely redundant) is pre-existing and unchanged.

## Checklist

- [x] `dotnet build KnightBus.slnx` and `dotnet test` pass — 308/308 across 10 suites, build clean apart from pre-existing `NU1510`
- [x] `dotnet csharpier check .` passes
- [x] Tests cover the change — no new tests; this is a version sweep, and the existing suites are the coverage
- [x] Documentation under `docs/` is updated, if the change is user-visible — N/A, no doc references a dependency version
- [x] `<Version>` is bumped in the affected `.csproj` and `CHANGELOG.md` has an entry — twelve packages, plus entries in the three per-package changelogs (`KnightBus.Core`, `KnightBus.Azure.ServiceBus`, `KnightBus.PostgreSql`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176nyGkxqpWKrvJAEpwYtnx
