### PR TITLE
chore(deps): refresh the locked docs toolchain

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,10 +7,13 @@
 #     pip install --require-hashes --only-binary :all: -r docs/requirements.txt
 #
 # Hashes cover every distribution PyPI publishes for each version, so the file is
-# platform independent.
+# platform independent. The resolved *set* is not: it is the resolution for the
+# Python the Docs workflow pins (3.12). On 3.9 mkdocs also pulls in
+# importlib_metadata and zipp, which that marker excludes from 3.10 up.
 #
-# To upgrade: bump mkdocs-material, reinstall into a clean venv, `pip freeze` the
-# result, and regenerate the hashes from PyPI for each pinned version.
+# To upgrade: bump mkdocs-material, reinstall into a clean venv on the same Python
+# as the workflow, `pip freeze` the result, and regenerate the hashes from PyPI for
+# each pinned version.
 #
 # Excluded from the built site via `exclude_docs` in mkdocs.yml.
 
@@ -20,9 +23,9 @@ mkdocs-material==9.7.7 \
 Jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
-Markdown==3.9 \
-    --hash=sha256:9f4d91ed810864ea88a6f32c07ba8bee1346c0cc1f6b1f9f6c822f2a9667d280 \
-    --hash=sha256:d2900fe1782bd33bdbbd56859defef70c2e78fc46668f8eb9df3128138f2cb6a
+Markdown==3.10.3 \
+    --hash=sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f \
+    --hash=sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea
 MarkupSafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
@@ -193,14 +196,13 @@ Pygments==2.21.0 \
 babel==2.18.0 \
     --hash=sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d \
     --hash=sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35
-backrefs==6.2 \
-    --hash=sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be \
-    --hash=sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8 \
-    --hash=sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b \
-    --hash=sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7 \
-    --hash=sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90 \
-    --hash=sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7 \
-    --hash=sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49
+backrefs==8.0 \
+    --hash=sha256:4a627b817fd2dce43b79ab48da63613340509381cd8ce0897078a0bce79a2ab8 \
+    --hash=sha256:601ce68ca12385dbda06ce264406b4c4210cf5b79fd0fd627592365c92f29a88 \
+    --hash=sha256:87f0fae8c5f207fe9f4b2887efc71d42f4900ac78faa1af08d675ef303692dc5 \
+    --hash=sha256:9ec96efa080938be92323e8e730e57718c9c88eb15ad70bbef4e1766df591408 \
+    --hash=sha256:b556cd7d36c3a3a2f256b89590b176b8eddfb73bcfaee3a3ddd84ea66d21ce50 \
+    --hash=sha256:f0c35cf0102ba6b6070c12a492be3c1c1d3f5839529784b9a9565d6d04569a01
 certifi==2026.7.22 \
     --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775 \
     --hash=sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55
@@ -377,9 +379,9 @@ charset-normalizer==3.5.1 \
     --hash=sha256:fd0350afdc3aabd5576f60ea109228bd5538139713c7b094c5cd27c73a98bc6f \
     --hash=sha256:fd0a274c0e5f9a21565cd9d3dd749b61f96b7aa1e20a93aa1ba4029518f2e5c0 \
     --hash=sha256:fdb8a068947befafba9952162645dc2fecaeb400e64584829ed5e9b2fbe21a7f
-click==8.1.8 \
-    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
-    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
+click==8.5.0 \
+    --hash=sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360 \
+    --hash=sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34
 colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
@@ -389,9 +391,6 @@ ghp-import==2.1.0 \
 idna==3.19 \
     --hash=sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15 \
     --hash=sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4
-importlib_metadata==8.7.1 \
-    --hash=sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb \
-    --hash=sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151
 mergedeep==1.3.4 \
     --hash=sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8 \
     --hash=sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307
@@ -413,27 +412,27 @@ paginate==0.5.7 \
 pathspec==1.1.1 \
     --hash=sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a \
     --hash=sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189
-platformdirs==4.4.0 \
-    --hash=sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85 \
-    --hash=sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf
-pymdown-extensions==10.21.3 \
-    --hash=sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354 \
-    --hash=sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6
+platformdirs==4.11.4 \
+    --hash=sha256:e34ff91a24bcddc6d939b878bdf3f5c437c9c46fe9e212b1bf455fdf1ee57586 \
+    --hash=sha256:f3373be828247211d0febabea97e238c3dfde8a60b3c90c32756fb52cb21556d
+pymdown-extensions==11.0.2 \
+    --hash=sha256:259910762019732caa1dfd76f3faa62c59f191d46573e80bcb1d13c0f675bbe5 \
+    --hash=sha256:9506fcbe66fa355a775b768084334238dd6805020ac4b92bea0c0dda6f8f223d
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
 pyyaml_env_tag==1.1 \
     --hash=sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04 \
     --hash=sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff
-requests==2.32.5 \
-    --hash=sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6 \
-    --hash=sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf
+requests==2.34.2 \
+    --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0 \
+    --hash=sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
 watchdog==6.0.0 \
     --hash=sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a \
     --hash=sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2 \
@@ -465,6 +464,3 @@ watchdog==6.0.0 \
     --hash=sha256:e6f0e77c9417e7cd62af82529b10563db3423625c5fce018430b249bf977f9e8 \
     --hash=sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c \
     --hash=sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2
-zipp==3.23.1 \
-    --hash=sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc \
-    --hash=sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110


### PR DESCRIPTION
## What this changes

Regenerates `docs/requirements.txt` following the procedure written in its own header: clean venv on the Python the Docs workflow pins (3.12), install `mkdocs-material`, `pip freeze`, then regenerate hashes from PyPI for every pinned version.

**This clears all five open Dependabot alerts.** All of them were in this file:

| Package | Was | Now | Advisories |
| --- | --- | --- | --- |
| `pymdown-extensions` | 10.21.3 | **11.0.2** | GHSA-gm37-52c6-37mw (high), GHSA-9xwg-3r6f-jcx2 (moderate) — first patched 11.0.1 |
| `urllib3` | 2.6.3 | **2.7.0** | GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j (both high) — first patched 2.7.0 |
| `requests` | 2.32.5 | **2.34.2** | GHSA-gc5v-m9x4-r6x2 (moderate) — first patched 2.33.0 |

Carried along by the same resolution: `Markdown` 3.9 → 3.10.3, `click` 8.1.8 → 8.5.0, `backrefs` 6.2 → 8.0, `platformdirs` 4.4.0 → 4.11.4. `mkdocs-material` itself is already current at 9.7.7, so this is a transitive refresh rather than a version bump of the root.

Docs-only: nothing here reaches a published package, so no `<Version>` bump and no `CHANGELOG.md` entry.

## Notes for the reviewer

**`importlib_metadata` and `zipp` are removed, not downgraded.** `mkdocs` requires `importlib-metadata` only under `python_version < "3.10"`, so neither is part of the resolution on 3.12 — they were being installed for nothing. The previous lock looks to have been frozen on an older Python. This does make the pinned *set* Python-version specific in a way the hashes are not, so the header comment now says so explicitly and tells the next person to use the same Python as the workflow.

**Why this is one PR rather than seven Dependabot ones.** `--require-hashes` means a version line cannot move without its hashes moving too, which is why every pip Dependabot PR against this file was unmergeable as opened — they edit the pin and leave the old hashes. `dependabot.yml` already notes this. A single regeneration keeps the lock internally consistent.

**Verification.** I checked the generator against the file it was replacing: for unchanged pins it reproduces the existing hashes byte-for-byte, including `watchdog`'s 30 — which confirms the convention is *all* distributions PyPI publishes for a version (wheels and sdist), sorted, not wheels only. Then, in a fresh 3.12 venv, exactly what CI runs:

```
pip install --require-hashes --only-binary :all: -r docs/requirements.txt   # 29 packages, no hash mismatch
mkdocs build --strict                                                       # exit 0
```

(`mkdocs build` prints a red banner about the upcoming MkDocs 2.0 — that is Material's own advisory, not a build failure.)

## Checklist

- [x] `dotnet build KnightBus.slnx` and `dotnet test` pass — N/A, no .NET code touched
- [x] `dotnet csharpier check .` passes — N/A
- [x] Tests cover the change — the Docs workflow is the test; it installs with `--require-hashes` and builds `--strict`
- [x] Documentation under `docs/` is updated, if the change is user-visible — N/A, no rendered content changes
- [x] `<Version>` is bumped in the affected `.csproj` and `CHANGELOG.md` has an entry — N/A, no package affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176nyGkxqpWKrvJAEpwYtnx
