### PR TITLE
chore(deps): bump csharpier from 1.2.1 to 1.3.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "1.2.1",
+      "version": "1.3.0",
       "commands": ["csharpier"]
     }
   }

--- a/src/KnightBus.Azure.ServiceBus/ServiceBusMessageStateHandler.cs
+++ b/src/KnightBus.Azure.ServiceBus/ServiceBusMessageStateHandler.cs
@@ -34,7 +34,8 @@ internal class ServiceBusMessageStateHandler<T> : IMessageStateHandler<T>
     public IDictionary<string, string> MessageProperties =>
         _sbMessage
             .ApplicationProperties?.Where(kvp => kvp.Value is string)
-            .ToDictionary(k => k.Key, k => k.Value.ToString()!) ?? new Dictionary<string, string>();
+            .ToDictionary(k => k.Key, k => k.Value.ToString()!)
+        ?? new Dictionary<string, string>();
 
     public async Task CompleteAsync()
     {

--- a/tests/KnightBus.PostgreSql.Tests.Integration/PostgresBusTests.cs
+++ b/tests/KnightBus.PostgreSql.Tests.Integration/PostgresBusTests.cs
@@ -91,7 +91,8 @@ DROP TABLE IF EXISTS knightbus.t_bus_test_topic;"
                 .DataSource.CreateCommand(
                     $"SELECT COUNT(*) FROM knightbus.q_{AutoMessageMapper.GetQueueName<TestCommand>()};"
                 )
-                .ExecuteScalarAsync() ?? 0
+                .ExecuteScalarAsync()
+            ?? 0
         );
 
         messagesCount.Should().Be(2);
@@ -118,7 +119,8 @@ DROP TABLE IF EXISTS knightbus.t_bus_test_topic;"
                 .DataSource.CreateCommand(
                     $"SELECT COUNT(*) FROM knightbus.q_{AutoMessageMapper.GetQueueName<TestCommand>()};"
                 )
-                .ExecuteScalarAsync() ?? 0
+                .ExecuteScalarAsync()
+            ?? 0
         );
 
         messagesCount.Should().Be(100_000);


### PR DESCRIPTION
## What this changes

Bumps the `csharpier` tool in `.config/dotnet-tools.json` to 1.3.0 and applies the resulting reformat. Supersedes #224.

This was deliberately held out of the dependency sweep in #231, on the grounds that a formatter bump can reflow files repo-wide and should not ride along inside another diff. It turns out to be nearly free — **three null-coalescing operators move onto their own line, across two files:**

```diff
-            .ToDictionary(k => k.Key, k => k.Value.ToString()!) ?? new Dictionary<string, string>();
+            .ToDictionary(k => k.Key, k => k.Value.ToString()!)
+        ?? new Dictionary<string, string>();
```

That comes from 1.2.2, *"null coalescing is now consistently broken"*, which puts `??` on a new line rather than trailing the preceding method chain. Nothing else in the repo changes shape.

## Notes for the reviewer

**No XML reflow, which was the risk worth checking.** The 1.2.x line replaced CSharpier's XML parser and changed how empty lines between elements and attribute encoding are handled, and 1.3.0 added configurable strict/ignore XML whitespace modes. Given how much lives in `Directory.Packages.props` and the `.csproj` files, that could have been a large diff — but every XML file in the repo is already formatted the way 1.3.0 wants, including the wrapped multi-line `<PackageVersion />` elements.

**One renamed flag, not used here.** 1.3.0 renames `--compilation-errors-as-warnings` to `--syntax-errors-as-warnings`, and changes XML syntax errors to fail rather than pass through. Neither `dotnet.yaml` nor the `.githooks` pre-commit hook passes that flag, so nothing needed updating.

**Verification.** `dotnet csharpier check .` is clean, `dotnet build KnightBus.slnx --configuration Release` succeeds (only the pre-existing `NU1510`), and the full suite is 308/308 across 10 suites. The reformat touches an integration test file, which is why I ran the integration suites rather than just the unit ones.

Docs-adjacent aside, not part of this PR: `csharpier check .` from the repo root also walks `.claude/`, so a stale git worktree at `.claude/worktrees/from-master` (registered, pointing at the pre-restructure layout) shows up as two unformatted files locally. CI never sees it since it checks out fresh. `git worktree remove .claude/worktrees/from-master` clears it if it is no longer wanted.

## Checklist

- [x] `dotnet build KnightBus.slnx` and `dotnet test` pass — 308/308 across 10 suites
- [x] `dotnet csharpier check .` passes
- [x] Tests cover the change — N/A, formatting only; the existing suites confirm nothing broke
- [x] Documentation under `docs/` is updated, if the change is user-visible — N/A, not user-visible
- [x] `<Version>` is bumped in the affected `.csproj` and `CHANGELOG.md` has an entry — N/A, no package affected; the two reformatted files are cosmetic and change no compiled behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176nyGkxqpWKrvJAEpwYtnx
