### PR TITLE
feat(postgres): add priority queueing for commands

### DIFF
--- a/src/KnightBus.Messages/IPriority.cs
+++ b/src/KnightBus.Messages/IPriority.cs
@@ -1,0 +1,10 @@
+namespace KnightBus.Messages;
+
+/// <summary>
+/// Marks a message as having a processing priority. Higher values are processed first.
+/// Only honored by transports that support priority queueing (currently PostgreSql).
+/// </summary>
+public interface IPriority
+{
+    int Priority { get; set; }
+}

--- a/src/KnightBus.PostgreSql/PostgresBaseClient.cs
+++ b/src/KnightBus.PostgreSql/PostgresBaseClient.cs
@@ -43,7 +43,7 @@ WITH cte AS
         SELECT message_id
         FROM {SchemaName}.{_prefix}_{_queueName}
         WHERE visibility_timeout <= clock_timestamp()
-        ORDER BY message_id ASC
+        ORDER BY priority DESC, message_id ASC
         LIMIT ($1)
         FOR UPDATE SKIP LOCKED
     )

--- a/src/KnightBus.PostgreSql/PostgresBus.cs
+++ b/src/KnightBus.PostgreSql/PostgresBus.cs
@@ -105,7 +105,7 @@ public class PostgresBus : IPostgresBus
     private static async Task BatchInsert(
         NpgsqlConnection connection,
         string queueName,
-        List<(byte[] Message, byte[]? Properties)> rows,
+        List<(byte[] Message, byte[]? Properties, int Priority)> rows,
         TimeSpan? delay,
         CancellationToken ct
     )
@@ -116,7 +116,7 @@ public class PostgresBus : IPostgresBus
             batch.BatchCommands.Add(
                 new NpgsqlBatchCommand(
                     //lang=postgresql
-                    $"INSERT INTO {SchemaName}.{QueuePrefix}_{queueName} (visibility_timeout, message, properties) VALUES (now() + $1, $2, $3)"
+                    $"INSERT INTO {SchemaName}.{QueuePrefix}_{queueName} (visibility_timeout, message, properties, priority) VALUES (now() + $1, $2, $3, $4)"
                 )
                 {
                     Parameters =
@@ -132,6 +132,7 @@ public class PostgresBus : IPostgresBus
                             Value = (object?)row.Properties ?? DBNull.Value,
                             NpgsqlDbType = NpgsqlDbType.Jsonb,
                         },
+                        new NpgsqlParameter<int> { TypedValue = row.Priority },
                     },
                 }
             );
@@ -144,14 +145,14 @@ public class PostgresBus : IPostgresBus
     private static async Task BatchCopy(
         NpgsqlConnection connection,
         string queueName,
-        List<(byte[] Message, byte[]? Properties)> rows,
+        List<(byte[] Message, byte[]? Properties, int Priority)> rows,
         TimeSpan? delay,
         CancellationToken ct
     )
     {
         string sql =
             //lang=postgresql
-            $"COPY {SchemaName}.{QueuePrefix}_{queueName} (visibility_timeout, message, properties) FROM STDIN (FORMAT binary)";
+            $"COPY {SchemaName}.{QueuePrefix}_{queueName} (visibility_timeout, message, properties, priority) FROM STDIN (FORMAT binary)";
 
         await using var importer = await connection
             .BeginBinaryImportAsync(sql, ct)
@@ -171,6 +172,7 @@ public class PostgresBus : IPostgresBus
                 await importer
                     .WriteAsync(row.Properties, NpgsqlDbType.Jsonb, ct)
                     .ConfigureAwait(false);
+            await importer.WriteAsync(row.Priority, NpgsqlDbType.Integer, ct).ConfigureAwait(false);
         }
 
         await importer.CompleteAsync(ct).ConfigureAwait(false);
@@ -245,19 +247,19 @@ public class PostgresBus : IPostgresBus
 
     // Pre-processors can perform slow I/O such as attachment uploads, so all rows are
     // serialized before a connection is opened or a COPY transaction is started
-    private async Task<List<(byte[] Message, byte[]? Properties)>> SerializeMessagesAsync<T>(
-        IEnumerable<T> messages,
-        CancellationToken ct
-    )
+    private async Task<
+        List<(byte[] Message, byte[]? Properties, int Priority)>
+    > SerializeMessagesAsync<T>(IEnumerable<T> messages, CancellationToken ct)
         where T : IMessage
     {
-        var rows = new List<(byte[], byte[]?)>();
+        var rows = new List<(byte[], byte[]?, int)>();
         foreach (var message in messages)
         {
             rows.Add(
                 (
                     _serializer.Serialize(message),
-                    await SerializePropertiesAsync(message, ct).ConfigureAwait(false)
+                    await SerializePropertiesAsync(message, ct).ConfigureAwait(false),
+                    message is IPriority priority ? priority.Priority : 0
                 )
             );
         }

--- a/src/KnightBus.PostgreSql/PostgresChannelReceiver.cs
+++ b/src/KnightBus.PostgreSql/PostgresChannelReceiver.cs
@@ -34,6 +34,13 @@ public class PostgresChannelReceiver<T> : IChannelReceiver
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        // Runs on every startup, not just when the table is missing, so already-deployed
+        // queues pick up schema changes (e.g. new columns) added by a newer library version
+        await QueueInitializer.InitQueue(
+            PostgresQueueName.Create(AutoMessageMapper.GetQueueName<T>()),
+            _npgsqlDataSource
+        );
+
         _queueClient = new PostgresQueueClient<T>(_npgsqlDataSource, _serializer);
         var pump = new PostgresMessagePump<T>(
             Settings,

--- a/src/KnightBus.PostgreSql/PostgresSubscriptionChannelReceiver.cs
+++ b/src/KnightBus.PostgreSql/PostgresSubscriptionChannelReceiver.cs
@@ -37,6 +37,14 @@ public class PostgresSubscriptionChannelReceiver<T> : IChannelReceiver
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        // Runs on every startup, not just when the table is missing, so already-deployed
+        // subscriptions pick up schema changes (e.g. new columns) added by a newer library version
+        await QueueInitializer.InitSubscription(
+            PostgresQueueName.Create(AutoMessageMapper.GetQueueName<T>()),
+            PostgresQueueName.Create(_subscription.Name),
+            _npgsqlDataSource
+        );
+
         _queueClient = new PostgresSubscriptionClient<T>(
             _npgsqlDataSource,
             _serializer,

--- a/src/KnightBus.PostgreSql/QueueInitializer.cs
+++ b/src/KnightBus.PostgreSql/QueueInitializer.cs
@@ -218,7 +218,9 @@ CREATE TABLE IF NOT EXISTS {SchemaName}.metadata (
         var createIndexCmd = new NpgsqlCommand(
             @$"
 CREATE INDEX IF NOT EXISTS {SchemaName}_{prefix}_{queueName}_visibility_timeout_idx
-ON {SchemaName}.{prefix}_{queueName} (visibility_timeout ASC);",
+ON {SchemaName}.{prefix}_{queueName} (visibility_timeout ASC);
+CREATE INDEX IF NOT EXISTS {SchemaName}_{prefix}_{queueName}_priority_idx
+ON {SchemaName}.{prefix}_{queueName} (visibility_timeout ASC, priority DESC, message_id ASC);",
             connection
         );
         return createIndexCmd;
@@ -259,7 +261,8 @@ CREATE TABLE IF NOT EXISTS {SchemaName}.{prefix}_{queueName} (
     visibility_timeout TIMESTAMP WITH TIME ZONE NOT NULL,
     message JSONB,
     properties JSONB
-);",
+);
+ALTER TABLE {SchemaName}.{prefix}_{queueName} ADD COLUMN IF NOT EXISTS priority INT NOT NULL DEFAULT 0;",
             connection
         );
         return createQueueCmd;

--- a/tests/KnightBus.PostgreSql.Tests.Integration/PostgresBusTests.cs
+++ b/tests/KnightBus.PostgreSql.Tests.Integration/PostgresBusTests.cs
@@ -184,6 +184,109 @@ DROP TABLE IF EXISTS knightbus.t_bus_test_topic;"
     }
 
     [Test]
+    public async Task GetMessages_HigherPriorityMessageIsFetchedFirst()
+    {
+        await _postgresBus.SendAsync(
+            new TestCommand { MessageBody = "default priority" },
+            default
+        );
+        await _postgresBus.SendAsync(
+            new TestCommand { MessageBody = "urgent", Priority = 10 },
+            default
+        );
+
+        var messages = _postgresQueueClient
+            .GetMessagesAsync(1, 100, default)
+            .ToBlockingEnumerable()
+            .ToList();
+
+        messages.Single().Message.MessageBody.Should().Be("urgent");
+    }
+
+    [Test]
+    public async Task GetMessages_SamePriorityPreservesInsertionOrder()
+    {
+        await _postgresBus.SendAsync<TestCommand>(
+            [
+                new TestCommand { MessageBody = "first", Priority = 5 },
+                new TestCommand { MessageBody = "second", Priority = 5 },
+            ],
+            default
+        );
+
+        var messages = _postgresQueueClient
+            .GetMessagesAsync(2, 100, default)
+            .ToBlockingEnumerable()
+            .ToList();
+
+        messages.Count.Should().Be(2);
+        messages[0].Message.MessageBody.Should().Be("first");
+        messages[1].Message.MessageBody.Should().Be("second");
+    }
+
+    [Test]
+    public async Task InitQueue_AddsPriorityColumnToExistingTable()
+    {
+        var legacyQueueName = PostgresQueueName.Create("legacy_priority_queue");
+
+        // Simulate a queue table created before priority support existed (no `priority` column)
+        await PostgresSetup
+            .DataSource.CreateCommand(
+                @"
+CREATE SCHEMA IF NOT EXISTS knightbus;
+CREATE TABLE IF NOT EXISTS knightbus.q_legacy_priority_queue (
+    message_id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    read_count SMALLINT DEFAULT 0 NOT NULL,
+    enqueued_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    visibility_timeout TIMESTAMP WITH TIME ZONE NOT NULL,
+    message JSONB,
+    properties JSONB
+);"
+            )
+            .ExecuteNonQueryAsync();
+
+        try
+        {
+            // What an upgraded host runs automatically at receiver startup
+            await QueueInitializer.InitQueue(legacyQueueName, PostgresSetup.DataSource);
+
+            var serializer = new MicrosoftJsonSerializer();
+            await using var connection = await PostgresSetup.DataSource.OpenConnectionAsync();
+            await using var insertCmd = new NpgsqlCommand(
+                "INSERT INTO knightbus.q_legacy_priority_queue (visibility_timeout, message, priority) VALUES (now(), $1, $2)",
+                connection
+            );
+            insertCmd.Parameters.Add(
+                new NpgsqlParameter
+                {
+                    Value = serializer.Serialize(new TestCommand { MessageBody = "migrated" }),
+                    NpgsqlDbType = NpgsqlDbType.Jsonb,
+                }
+            );
+            insertCmd.Parameters.Add(new NpgsqlParameter<int> { TypedValue = 5 });
+            await insertCmd.ExecuteNonQueryAsync();
+
+            var legacyQueueClient = new PostgresBaseClient<TestCommand>(
+                PostgresSetup.DataSource,
+                serializer,
+                PostgresConstants.QueuePrefix,
+                legacyQueueName
+            );
+
+            var messages = legacyQueueClient
+                .GetMessagesAsync(1, 100, default)
+                .ToBlockingEnumerable()
+                .ToList();
+
+            messages.Single().Message.MessageBody.Should().Be("migrated");
+        }
+        finally
+        {
+            await _postgresManagementClient.DeleteQueue(legacyQueueName, default);
+        }
+    }
+
+    [Test]
     public async Task SendAsync_WithPreProcessors_StoresPropertiesOnMessage()
     {
         var bus = new PostgresBus(
@@ -579,9 +682,10 @@ WHERE message_id = {message[0].Id}"
     }
 }
 
-public class TestCommand : IPostgresCommand
+public class TestCommand : IPostgresCommand, IPriority
 {
     public string MessageBody { get; set; }
+    public int Priority { get; set; }
 }
 
 public class BusTestEvent : IPostgresEvent


### PR DESCRIPTION
Messages can implement IPriority (KnightBus.Messages) to declare an int Priority; the PostgreSql transport locks/fetches higher-priority messages first, tie-broken by message_id asc to preserve FIFO within a priority.

Schema init now runs eagerly on every receiver startup (not just when a table is missing) so already-deployed queues pick up the new priority column automatically. Scoped to commands (Send/Schedule) for now; Publish (events) is unaffected.

## What this changes

<!-- What the change does, and why. Link the issue if there is one. -->

## Notes for the reviewer

<!-- Anything worth knowing: a decision you went back and forth on, a limitation you accepted. -->

## Checklist

- [ ] `dotnet build KnightBus.slnx` and `dotnet test` pass
- [ ] `dotnet csharpier check .` passes (CI fails on unformatted code)
- [ ] Tests cover the change
- [ ] Documentation under `docs/` is updated, if the change is user-visible
- [ ] `<Version>` is bumped in the affected `.csproj` and `CHANGELOG.md` has an entry, if this
      should be released
