### PR TITLE
fix: Fix resolving of multiple processors sharing the same schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+# 2026-08-28
+
+### KnightBus.Schedule 15.3.1
+* Fixed: when multiple processors implemented `IProcessSchedule<T>` for the same schedule, every trigger executed only the last-registered processor (once per registration) and the others never ran. Each scheduled job now resolves the specific processor it was created for
+
 # 2026-08-27
 
 ### KnightBus.PostgreSql 4.2.0

--- a/src/KnightBus.Schedule/JobExecutor.cs
+++ b/src/KnightBus.Schedule/JobExecutor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using KnightBus.Core;
@@ -66,7 +67,11 @@ internal class JobExecutor<T, TProcessor> : IJob
                 )
                 using (var scopedDependencyInjection = _dependencyInjection.GetScope())
                 {
-                    var processor = scopedDependencyInjection.GetInstance<IProcessSchedule<T>>();
+                    // Multiple processors may share the same schedule; resolve the one this job was created for
+                    var processor = scopedDependencyInjection
+                        .GetInstances<IProcessSchedule<T>>()
+                        .OfType<TProcessor>()
+                        .First();
                     await processor.ProcessAsync(linkedTokenSource.Token).ConfigureAwait(false);
                 }
             }

--- a/src/KnightBus.Schedule/KnightBus.Schedule.csproj
+++ b/src/KnightBus.Schedule/KnightBus.Schedule.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>KnightBus Chron Scheduler</Description>
-    <Version>15.3.0$(VersionSuffix)</Version>
+    <Version>15.3.1$(VersionSuffix)</Version>
     <PackageTags>knightbus;quartz;schedule;trigger</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/KnightBus.Schedule.Tests.Unit/JobExecutorTests.cs
+++ b/tests/KnightBus.Schedule.Tests.Unit/JobExecutorTests.cs
@@ -2,7 +2,9 @@
 using System.Threading;
 using System.Threading.Tasks;
 using KnightBus.Core;
+using KnightBus.Core.DependencyInjection;
 using KnightBus.Core.Singleton;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
@@ -31,7 +33,8 @@ public class JobExecutorTests
         var processor = new Mock<IProcessSchedule<DummySchedule>>();
         var di = new Mock<IDependencyInjection>();
         di.Setup(x => x.GetScope()).Returns(di.Object);
-        di.Setup(x => x.GetInstance<IProcessSchedule<DummySchedule>>()).Returns(processor.Object);
+        di.Setup(x => x.GetInstances<IProcessSchedule<DummySchedule>>())
+            .Returns(new[] { processor.Object });
         var executor = new JobExecutor<DummySchedule, IProcessSchedule<DummySchedule>>(
             Mock.Of<ILogger>(),
             lockManager.Object,
@@ -60,7 +63,8 @@ public class JobExecutorTests
         var processor = new Mock<IProcessSchedule<DummySchedule>>();
         var di = new Mock<IDependencyInjection>();
         di.Setup(x => x.GetScope()).Returns(di.Object);
-        di.Setup(x => x.GetInstance<IProcessSchedule<DummySchedule>>()).Returns(processor.Object);
+        di.Setup(x => x.GetInstances<IProcessSchedule<DummySchedule>>())
+            .Returns(new[] { processor.Object });
         var executor = new JobExecutor<DummySchedule, IProcessSchedule<DummySchedule>>(
             Mock.Of<ILogger>(),
             lockManager.Object,
@@ -89,7 +93,8 @@ public class JobExecutorTests
         processor.Setup(x => x.ProcessAsync(It.IsAny<CancellationToken>())).Throws<Exception>();
         var di = new Mock<IDependencyInjection>();
         di.Setup(x => x.GetScope()).Returns(di.Object);
-        di.Setup(x => x.GetInstance<IProcessSchedule<DummySchedule>>()).Returns(processor.Object);
+        di.Setup(x => x.GetInstances<IProcessSchedule<DummySchedule>>())
+            .Returns(new[] { processor.Object });
         var executor = new JobExecutor<DummySchedule, IProcessSchedule<DummySchedule>>(
             Mock.Of<ILogger>(),
             lockManager.Object,
@@ -118,7 +123,8 @@ public class JobExecutorTests
         var processor = new Mock<IProcessSchedule<DummySchedule>>();
         var di = new Mock<IDependencyInjection>();
         di.Setup(x => x.GetScope()).Returns(di.Object);
-        di.Setup(x => x.GetInstance<IProcessSchedule<DummySchedule>>()).Returns(processor.Object);
+        di.Setup(x => x.GetInstances<IProcessSchedule<DummySchedule>>())
+            .Returns(new[] { processor.Object });
         var executor = new JobExecutor<DummySchedule, IProcessSchedule<DummySchedule>>(
             Mock.Of<ILogger>(),
             lockManager.Object,
@@ -130,9 +136,72 @@ public class JobExecutorTests
         processor.Verify(x => x.ProcessAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Test]
+    public async Task Should_execute_own_processor_when_processors_share_schedule()
+    {
+        //arrange
+        var lockHandle = new Mock<ISingletonLockHandle>();
+        var lockManager = new Mock<ISingletonLockManager>();
+        lockManager
+            .Setup(x =>
+                x.TryLockAsync(
+                    It.IsAny<string>(),
+                    TimeSpan.FromSeconds(60),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(lockHandle.Object);
+        var services = new ServiceCollection();
+        services
+            .RegisterSchedule<SharedScheduleProcessorOne, DummySchedule>()
+            .RegisterSchedule<SharedScheduleProcessorTwo, DummySchedule>();
+        using var provider = services.BuildServiceProvider();
+        using var di = new MicrosoftDependencyInjection(provider);
+        SharedScheduleProcessorOne.Invocations = 0;
+        SharedScheduleProcessorTwo.Invocations = 0;
+        var executorOne = new JobExecutor<DummySchedule, SharedScheduleProcessorOne>(
+            Mock.Of<ILogger>(),
+            lockManager.Object,
+            di
+        );
+        var executorTwo = new JobExecutor<DummySchedule, SharedScheduleProcessorTwo>(
+            Mock.Of<ILogger>(),
+            lockManager.Object,
+            di
+        );
+        //act
+        await executorOne.Execute(Mock.Of<IJobExecutionContext>());
+        await executorTwo.Execute(Mock.Of<IJobExecutionContext>());
+        //assert
+        Assert.That(SharedScheduleProcessorOne.Invocations, Is.EqualTo(1));
+        Assert.That(SharedScheduleProcessorTwo.Invocations, Is.EqualTo(1));
+    }
+
     public class DummySchedule : ISchedule
     {
         public string CronExpression { get; } = null!;
         public TimeZoneInfo TimeZone => TimeZoneInfo.Utc;
+    }
+
+    public class SharedScheduleProcessorOne : IProcessSchedule<DummySchedule>
+    {
+        public static int Invocations;
+
+        public Task ProcessAsync(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref Invocations);
+            return Task.CompletedTask;
+        }
+    }
+
+    public class SharedScheduleProcessorTwo : IProcessSchedule<DummySchedule>
+    {
+        public static int Invocations;
+
+        public Task ProcessAsync(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref Invocations);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/KnightBus.Schedule.Tests.Unit/ScheduleProcessorLockingTests.cs
+++ b/tests/KnightBus.Schedule.Tests.Unit/ScheduleProcessorLockingTests.cs
@@ -80,7 +80,8 @@ public class ScheduleProcessorLockingTests
 
         public IEnumerable<T> GetInstances<T>()
         {
-            throw new NotImplementedException();
+            if (_processor is T instance)
+                yield return instance;
         }
 
         public IEnumerable<Type> GetOpenGenericRegistrations(Type openGeneric)


### PR DESCRIPTION
Processors sharing the same schedule T are all registered under IProcessSchedule<T>, but JobExecutor resolved its processor via GetInstance<IProcessSchedule<T>>(), which always returns the last registration. So on every trigger, one processor ran once per registered processor and the others never ran.

Fixed by resolving all IProcessSchedule<T> instances and picking the TProcessor the job was created for. Added a regression test covering two processors on a shared schedule.